### PR TITLE
Boundary lang fix: "{en,es}" → "lang:{en,es}"

### DIFF
--- a/boundaries/build/index.json
+++ b/boundaries/build/index.json
@@ -607,8 +607,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:agu",
@@ -625,8 +625,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:bcn",
@@ -643,8 +643,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:bcs",
@@ -661,8 +661,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:cam",
@@ -679,8 +679,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:coa",
@@ -697,8 +697,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:col",
@@ -715,8 +715,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:chp",
@@ -733,8 +733,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:chh",
@@ -751,8 +751,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:dur",
@@ -769,8 +769,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:gua",
@@ -787,8 +787,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:gro",
@@ -805,8 +805,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:hid",
@@ -823,8 +823,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:jal",
@@ -841,8 +841,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:mex",
@@ -859,8 +859,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:mic",
@@ -877,8 +877,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:mor",
@@ -895,8 +895,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:nay",
@@ -913,8 +913,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:nle",
@@ -931,8 +931,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:oax",
@@ -949,8 +949,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:pue",
@@ -967,8 +967,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:que",
@@ -985,8 +985,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:roo",
@@ -1003,8 +1003,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:slp",
@@ -1021,8 +1021,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:sin",
@@ -1039,8 +1039,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:son",
@@ -1057,8 +1057,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:tab",
@@ -1075,8 +1075,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:tam",
@@ -1093,8 +1093,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:tla",
@@ -1111,8 +1111,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:ver",
@@ -1129,8 +1129,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:yuc",
@@ -1147,8 +1147,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/state:zac",
@@ -1165,8 +1165,8 @@
       }
     ],
     "name_columns": {
-      "en": "label_en",
-      "es": "label_es"
+      "lang:en": "label_en",
+      "lang:es": "label_es"
     },
     "filter": {
       "match": "country:mx/federal-district:cmx",
@@ -1187,7 +1187,7 @@
       }
     ],
     "name_columns": {
-      "es": "NOMGEO"
+      "lang:es": "NOMGEO"
     },
     "filter": {
       "match": "country:mx/state:mex/mun:nezahualcoyotl",
@@ -1208,7 +1208,7 @@
       }
     ],
     "name_columns": {
-      "es": "NOMGEO"
+      "lang:es": "NOMGEO"
     },
     "filter": {
       "match": "country:mx/state:pue/mun:puebla",
@@ -1229,7 +1229,7 @@
       }
     ],
     "name_columns": {
-      "es": "NOMGEO"
+      "lang:es": "NOMGEO"
     },
     "filter": {
       "match": "country:mx/state:mex/mun:ecatepec-de-morelos",
@@ -1250,7 +1250,7 @@
       }
     ],
     "name_columns": {
-      "es": "NOMGEO"
+      "lang:es": "NOMGEO"
     },
     "filter": {
       "match": "country:mx/state:jal/mun:guadalajara",
@@ -1271,7 +1271,7 @@
       }
     ],
     "name_columns": {
-      "es": "NOMGEO"
+      "lang:es": "NOMGEO"
     },
     "filter": {
       "match": "country:mx/state:chh/mun:juarez",
@@ -1292,7 +1292,7 @@
       }
     ],
     "name_columns": {
-      "es": "NOMGEO"
+      "lang:es": "NOMGEO"
     },
     "filter": {
       "match": "country:mx/state:gua/mun:leon",
@@ -1313,7 +1313,7 @@
       }
     ],
     "name_columns": {
-      "es": "NOMGEO"
+      "lang:es": "NOMGEO"
     },
     "filter": {
       "match": "country:mx/state:nle/mun:monterrey",
@@ -1334,7 +1334,7 @@
       }
     ],
     "name_columns": {
-      "es": "NOMGEO"
+      "lang:es": "NOMGEO"
     },
     "filter": {
       "match": "country:mx/state:bcn/mun:tijuana",
@@ -1355,7 +1355,7 @@
       }
     ],
     "name_columns": {
-      "es": "NOMGEO"
+      "lang:es": "NOMGEO"
     },
     "filter": {
       "match": "country:mx/state:jal/mun:zapopan",

--- a/executive/Q52634213/current/popolo-m17n.json
+++ b/executive/Q52634213/current/popolo-m17n.json
@@ -59,7 +59,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Ecatepec de Morelos"
+        "lang:es": "Ecatepec de Morelos"
       },
       "parent_id": "Q82112"
     },

--- a/executive/Q52634214/current/popolo-m17n.json
+++ b/executive/Q52634214/current/popolo-m17n.json
@@ -73,7 +73,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Tijuana"
+        "lang:es": "Tijuana"
       },
       "parent_id": "Q58731"
     },

--- a/executive/Q52634215/current/popolo-m17n.json
+++ b/executive/Q52634215/current/popolo-m17n.json
@@ -56,7 +56,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Puebla"
+        "lang:es": "Puebla"
       },
       "parent_id": "Q79923"
     },

--- a/executive/Q52634216/current/popolo-m17n.json
+++ b/executive/Q52634216/current/popolo-m17n.json
@@ -73,7 +73,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Guadalajara"
+        "lang:es": "Guadalajara"
       },
       "parent_id": "Q13160"
     },

--- a/executive/Q52634217/current/popolo-m17n.json
+++ b/executive/Q52634217/current/popolo-m17n.json
@@ -97,7 +97,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "León"
+        "lang:es": "León"
       },
       "parent_id": "Q46475"
     },

--- a/executive/Q52634218/current/popolo-m17n.json
+++ b/executive/Q52634218/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Juárez"
+        "lang:es": "Juárez"
       },
       "parent_id": "Q655"
     },

--- a/executive/Q52634219/current/popolo-m17n.json
+++ b/executive/Q52634219/current/popolo-m17n.json
@@ -51,7 +51,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Zapopan"
+        "lang:es": "Zapopan"
       },
       "parent_id": "Q13160"
     },

--- a/executive/Q52634220/current/popolo-m17n.json
+++ b/executive/Q52634220/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Nezahualcóyotl"
+        "lang:es": "Nezahualcóyotl"
       },
       "parent_id": "Q82112"
     },

--- a/executive/Q52634221/current/popolo-m17n.json
+++ b/executive/Q52634221/current/popolo-m17n.json
@@ -94,7 +94,7 @@
         "lang:en": "municipality of Nuevo León"
       },
       "name": {
-        "es": "Monterrey"
+        "lang:es": "Monterrey"
       },
       "parent_id": "Q15282"
     },

--- a/legislative/Q20014631/Q53546041/popolo-m17n.json
+++ b/legislative/Q20014631/Q53546041/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "I Local Electoral District of Durango",
-        "es": "I Distrito Electoral Local de Durango"
+        "lang:en": "I Local Electoral District of Durango",
+        "lang:es": "I Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "II Local Electoral District of Durango",
-        "es": "II Distrito Electoral Local de Durango"
+        "lang:en": "II Local Electoral District of Durango",
+        "lang:es": "II Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "III Local Electoral District of Durango",
-        "es": "III Distrito Electoral Local de Durango"
+        "lang:en": "III Local Electoral District of Durango",
+        "lang:es": "III Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "IV Local Electoral District of Durango",
-        "es": "IV Distrito Electoral Local de Durango"
+        "lang:en": "IV Local Electoral District of Durango",
+        "lang:es": "IV Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "V Local Electoral District of Durango",
-        "es": "V Distrito Electoral Local de Durango"
+        "lang:en": "V Local Electoral District of Durango",
+        "lang:es": "V Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "VI Local Electoral District of Durango",
-        "es": "VI Distrito Electoral Local de Durango"
+        "lang:en": "VI Local Electoral District of Durango",
+        "lang:es": "VI Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "VII Local Electoral District of Durango",
-        "es": "VII Distrito Electoral Local de Durango"
+        "lang:en": "VII Local Electoral District of Durango",
+        "lang:es": "VII Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "VIII Local Electoral District of Durango",
-        "es": "VIII Distrito Electoral Local de Durango"
+        "lang:en": "VIII Local Electoral District of Durango",
+        "lang:es": "VIII Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "IX Local Electoral District of Durango",
-        "es": "IX Distrito Electoral Local de Durango"
+        "lang:en": "IX Local Electoral District of Durango",
+        "lang:es": "IX Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "X Local Electoral District of Durango",
-        "es": "X Distrito Electoral Local de Durango"
+        "lang:en": "X Local Electoral District of Durango",
+        "lang:es": "X Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "XI Local Electoral District of Durango",
-        "es": "XI Distrito Electoral Local de Durango"
+        "lang:en": "XI Local Electoral District of Durango",
+        "lang:es": "XI Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "XII Local Electoral District of Durango",
-        "es": "XII Distrito Electoral Local de Durango"
+        "lang:en": "XII Local Electoral District of Durango",
+        "lang:es": "XII Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "XIII Local Electoral District of Durango",
-        "es": "XIII Distrito Electoral Local de Durango"
+        "lang:en": "XIII Local Electoral District of Durango",
+        "lang:es": "XIII Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "XIV Local Electoral District of Durango",
-        "es": "XIV Distrito Electoral Local de Durango"
+        "lang:en": "XIV Local Electoral District of Durango",
+        "lang:es": "XIV Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Durango"
       },
       "name": {
-        "en": "XV Local Electoral District of Durango",
-        "es": "XV Distrito Electoral Local de Durango"
+        "lang:en": "XV Local Electoral District of Durango",
+        "lang:es": "XV Distrito Electoral Local de Durango"
       },
       "parent_id": "Q79918"
     },

--- a/legislative/Q24337177/Q53546113/popolo-m17n.json
+++ b/legislative/Q24337177/Q53546113/popolo-m17n.json
@@ -74,8 +74,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "I Local Electoral District of Veracruz",
-        "es": "I Distrito Electoral Local de Veracruz"
+        "lang:en": "I Local Electoral District of Veracruz",
+        "lang:es": "I Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -98,8 +98,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "II Local Electoral District of Veracruz",
-        "es": "II Distrito Electoral Local de Veracruz"
+        "lang:en": "II Local Electoral District of Veracruz",
+        "lang:es": "II Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -122,8 +122,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "III Local Electoral District of Veracruz",
-        "es": "III Distrito Electoral Local de Veracruz"
+        "lang:en": "III Local Electoral District of Veracruz",
+        "lang:es": "III Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -146,8 +146,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "IV Local Electoral District of Veracruz",
-        "es": "IV Distrito Electoral Local de Veracruz"
+        "lang:en": "IV Local Electoral District of Veracruz",
+        "lang:es": "IV Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -170,8 +170,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "V Local Electoral District of Veracruz",
-        "es": "V Distrito Electoral Local de Veracruz"
+        "lang:en": "V Local Electoral District of Veracruz",
+        "lang:es": "V Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -194,8 +194,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "VI Local Electoral District of Veracruz",
-        "es": "VI Distrito Electoral Local de Veracruz"
+        "lang:en": "VI Local Electoral District of Veracruz",
+        "lang:es": "VI Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -218,8 +218,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "VII Local Electoral District of Veracruz",
-        "es": "VII Distrito Electoral Local de Veracruz"
+        "lang:en": "VII Local Electoral District of Veracruz",
+        "lang:es": "VII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -242,8 +242,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "VIII Local Electoral District of Veracruz",
-        "es": "VIII Distrito Electoral Local de Veracruz"
+        "lang:en": "VIII Local Electoral District of Veracruz",
+        "lang:es": "VIII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -266,8 +266,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "IX Local Electoral District of Veracruz",
-        "es": "IX Distrito Electoral Local de Veracruz"
+        "lang:en": "IX Local Electoral District of Veracruz",
+        "lang:es": "IX Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -290,8 +290,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "X Local Electoral District of Veracruz",
-        "es": "X Distrito Electoral Local de Veracruz"
+        "lang:en": "X Local Electoral District of Veracruz",
+        "lang:es": "X Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -314,8 +314,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XI Local Electoral District of Veracruz",
-        "es": "XI Distrito Electoral Local de Veracruz"
+        "lang:en": "XI Local Electoral District of Veracruz",
+        "lang:es": "XI Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -338,8 +338,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XII Local Electoral District of Veracruz",
-        "es": "XII Distrito Electoral Local de Veracruz"
+        "lang:en": "XII Local Electoral District of Veracruz",
+        "lang:es": "XII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -362,8 +362,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XIII Local Electoral District of Veracruz",
-        "es": "XIII Distrito Electoral Local de Veracruz"
+        "lang:en": "XIII Local Electoral District of Veracruz",
+        "lang:es": "XIII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -386,8 +386,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XIV Local Electoral District of Veracruz",
-        "es": "XIV Distrito Electoral Local de Veracruz"
+        "lang:en": "XIV Local Electoral District of Veracruz",
+        "lang:es": "XIV Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -410,8 +410,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XV Local Electoral District of Veracruz",
-        "es": "XV Distrito Electoral Local de Veracruz"
+        "lang:en": "XV Local Electoral District of Veracruz",
+        "lang:es": "XV Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -434,8 +434,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XVI Local Electoral District of Veracruz",
-        "es": "XVI Distrito Electoral Local de Veracruz"
+        "lang:en": "XVI Local Electoral District of Veracruz",
+        "lang:es": "XVI Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -458,8 +458,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XVII Local Electoral District of Veracruz",
-        "es": "XVII Distrito Electoral Local de Veracruz"
+        "lang:en": "XVII Local Electoral District of Veracruz",
+        "lang:es": "XVII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -482,8 +482,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Veracruz",
-        "es": "XVIII Distrito Electoral Local de Veracruz"
+        "lang:en": "XVIII Local Electoral District of Veracruz",
+        "lang:es": "XVIII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -506,8 +506,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XIX Local Electoral District of Veracruz",
-        "es": "XIX Distrito Electoral Local de Veracruz"
+        "lang:en": "XIX Local Electoral District of Veracruz",
+        "lang:es": "XIX Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -530,8 +530,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XX Local Electoral District of Veracruz",
-        "es": "XX Distrito Electoral Local de Veracruz"
+        "lang:en": "XX Local Electoral District of Veracruz",
+        "lang:es": "XX Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -554,8 +554,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXI Local Electoral District of Veracruz",
-        "es": "XXI Distrito Electoral Local de Veracruz"
+        "lang:en": "XXI Local Electoral District of Veracruz",
+        "lang:es": "XXI Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -578,8 +578,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXII Local Electoral District of Veracruz",
-        "es": "XXII Distrito Electoral Local de Veracruz"
+        "lang:en": "XXII Local Electoral District of Veracruz",
+        "lang:es": "XXII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -602,8 +602,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXIII Local Electoral District of Veracruz",
-        "es": "XXIII Distrito Electoral Local de Veracruz"
+        "lang:en": "XXIII Local Electoral District of Veracruz",
+        "lang:es": "XXIII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -626,8 +626,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXIV Local Electoral District of Veracruz",
-        "es": "XXIV Distrito Electoral Local de Veracruz"
+        "lang:en": "XXIV Local Electoral District of Veracruz",
+        "lang:es": "XXIV Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -650,8 +650,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXV Local Electoral District of Veracruz",
-        "es": "XXV Distrito Electoral Local de Veracruz"
+        "lang:en": "XXV Local Electoral District of Veracruz",
+        "lang:es": "XXV Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -674,8 +674,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXVI Local Electoral District of Veracruz",
-        "es": "XXVI Distrito Electoral Local de Veracruz"
+        "lang:en": "XXVI Local Electoral District of Veracruz",
+        "lang:es": "XXVI Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -698,8 +698,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXVII Local Electoral District of Veracruz",
-        "es": "XXVII Distrito Electoral Local de Veracruz"
+        "lang:en": "XXVII Local Electoral District of Veracruz",
+        "lang:es": "XXVII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -722,8 +722,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXVIII Local Electoral District of Veracruz",
-        "es": "XXVIII Distrito Electoral Local de Veracruz"
+        "lang:en": "XXVIII Local Electoral District of Veracruz",
+        "lang:es": "XXVIII Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -746,8 +746,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXIX Local Electoral District of Veracruz",
-        "es": "XXIX Distrito Electoral Local de Veracruz"
+        "lang:en": "XXIX Local Electoral District of Veracruz",
+        "lang:es": "XXIX Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },
@@ -770,8 +770,8 @@
         "lang:en": "local electoral district of Veracruz"
       },
       "name": {
-        "en": "XXX Local Electoral District of Veracruz",
-        "es": "XXX Distrito Electoral Local de Veracruz"
+        "lang:en": "XXX Local Electoral District of Veracruz",
+        "lang:es": "XXX Distrito Electoral Local de Veracruz"
       },
       "parent_id": "Q60130"
     },

--- a/legislative/Q254534/Q53546067/popolo-m17n.json
+++ b/legislative/Q254534/Q53546067/popolo-m17n.json
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "I Local Electoral District of Nuevo Leon",
-        "es": "I Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "I Local Electoral District of Nuevo Leon",
+        "lang:es": "I Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "II Local Electoral District of Nuevo Leon",
-        "es": "II Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "II Local Electoral District of Nuevo Leon",
+        "lang:es": "II Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "III Local Electoral District of Nuevo Leon",
-        "es": "III Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "III Local Electoral District of Nuevo Leon",
+        "lang:es": "III Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "IV Local Electoral District of Nuevo Leon",
-        "es": "IV Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "IV Local Electoral District of Nuevo Leon",
+        "lang:es": "IV Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "V Local Electoral District of Nuevo Leon",
-        "es": "V Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "V Local Electoral District of Nuevo Leon",
+        "lang:es": "V Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "VI Local Electoral District of Nuevo Leon",
-        "es": "VI Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "VI Local Electoral District of Nuevo Leon",
+        "lang:es": "VI Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "VII Local Electoral District of Nuevo Leon",
-        "es": "VII Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "VII Local Electoral District of Nuevo Leon",
+        "lang:es": "VII Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "VIII Local Electoral District of Nuevo Leon",
-        "es": "VIII Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "VIII Local Electoral District of Nuevo Leon",
+        "lang:es": "VIII Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "IX Local Electoral District of Nuevo Leon",
-        "es": "IX Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "IX Local Electoral District of Nuevo Leon",
+        "lang:es": "IX Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "X Local Electoral District of Nuevo Leon",
-        "es": "X Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "X Local Electoral District of Nuevo Leon",
+        "lang:es": "X Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XI Local Electoral District of Nuevo Leon",
-        "es": "XI Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XI Local Electoral District of Nuevo Leon",
+        "lang:es": "XI Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XII Local Electoral District of Nuevo Leon",
-        "es": "XII Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XII Local Electoral District of Nuevo Leon",
+        "lang:es": "XII Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XIII Local Electoral District of Nuevo Leon",
-        "es": "XIII Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XIII Local Electoral District of Nuevo Leon",
+        "lang:es": "XIII Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XIV Local Electoral District of Nuevo Leon",
-        "es": "XIV Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XIV Local Electoral District of Nuevo Leon",
+        "lang:es": "XIV Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XV Local Electoral District of Nuevo Leon",
-        "es": "XV Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XV Local Electoral District of Nuevo Leon",
+        "lang:es": "XV Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XVI Local Electoral District of Nuevo Leon",
-        "es": "XVI Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XVI Local Electoral District of Nuevo Leon",
+        "lang:es": "XVI Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XVII Local Electoral District of Nuevo Leon",
-        "es": "XVII Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XVII Local Electoral District of Nuevo Leon",
+        "lang:es": "XVII Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Nuevo Leon",
-        "es": "XVIII Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XVIII Local Electoral District of Nuevo Leon",
+        "lang:es": "XVIII Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XIX Local Electoral District of Nuevo Leon",
-        "es": "XIX Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XIX Local Electoral District of Nuevo Leon",
+        "lang:es": "XIX Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XX Local Electoral District of Nuevo Leon",
-        "es": "XX Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XX Local Electoral District of Nuevo Leon",
+        "lang:es": "XX Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XXI Local Electoral District of Nuevo Leon",
-        "es": "XXI Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XXI Local Electoral District of Nuevo Leon",
+        "lang:es": "XXI Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -553,8 +553,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XXII Local Electoral District of Nuevo Leon",
-        "es": "XXII Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XXII Local Electoral District of Nuevo Leon",
+        "lang:es": "XXII Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -577,8 +577,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XXIII Local Electoral District of Nuevo Leon",
-        "es": "XXIII Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XXIII Local Electoral District of Nuevo Leon",
+        "lang:es": "XXIII Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -601,8 +601,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XXIV Local Electoral District of Nuevo Leon",
-        "es": "XXIV Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XXIV Local Electoral District of Nuevo Leon",
+        "lang:es": "XXIV Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -625,8 +625,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XXV Local Electoral District of Nuevo Leon",
-        "es": "XXV Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XXV Local Electoral District of Nuevo Leon",
+        "lang:es": "XXV Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },
@@ -649,8 +649,8 @@
         "lang:en": "local electoral district of Nuevo Leon"
       },
       "name": {
-        "en": "XXVI Local Electoral District of Nuevo Leon",
-        "es": "XXVI Distrito Electoral Local de Nuevo Leon"
+        "lang:en": "XXVI Local Electoral District of Nuevo Leon",
+        "lang:es": "XXVI Distrito Electoral Local de Nuevo Leon"
       },
       "parent_id": "Q15282"
     },

--- a/legislative/Q2867085/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q2867085/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "90I Local Electoral District of Mexico City",
-        "es": "I Distrito Electoral Local de Ciudad de México"
+        "lang:en": "90I Local Electoral District of Mexico City",
+        "lang:es": "I Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "II Local Electoral District of Mexico City",
-        "es": "II Distrito Electoral Local de Ciudad de México"
+        "lang:en": "II Local Electoral District of Mexico City",
+        "lang:es": "II Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "III Local Electoral District of Mexico City",
-        "es": "III Distrito Electoral Local de Ciudad de México"
+        "lang:en": "III Local Electoral District of Mexico City",
+        "lang:es": "III Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "IV Local Electoral District of Mexico City",
-        "es": "IV Distrito Electoral Local de Ciudad de México"
+        "lang:en": "IV Local Electoral District of Mexico City",
+        "lang:es": "IV Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "V Local Electoral District of Mexico City",
-        "es": "V Distrito Electoral Local de Ciudad de México"
+        "lang:en": "V Local Electoral District of Mexico City",
+        "lang:es": "V Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "VI Local Electoral District of Mexico City",
-        "es": "VI Distrito Electoral Local de Ciudad de México"
+        "lang:en": "VI Local Electoral District of Mexico City",
+        "lang:es": "VI Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "VII Local Electoral District of Mexico City",
-        "es": "VII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "VII Local Electoral District of Mexico City",
+        "lang:es": "VII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "VIII Local Electoral District of Mexico City",
-        "es": "VIII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "VIII Local Electoral District of Mexico City",
+        "lang:es": "VIII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "IX Local Electoral District of Mexico City",
-        "es": "IX Distrito Electoral Local de Ciudad de México"
+        "lang:en": "IX Local Electoral District of Mexico City",
+        "lang:es": "IX Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "X Local Electoral District of Mexico City",
-        "es": "X Distrito Electoral Local de Ciudad de México"
+        "lang:en": "X Local Electoral District of Mexico City",
+        "lang:es": "X Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XI Local Electoral District of Mexico City",
-        "es": "XI Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XI Local Electoral District of Mexico City",
+        "lang:es": "XI Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XII Local Electoral District of Mexico City",
-        "es": "XII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XII Local Electoral District of Mexico City",
+        "lang:es": "XII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XIII Local Electoral District of Mexico City",
-        "es": "XIII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XIII Local Electoral District of Mexico City",
+        "lang:es": "XIII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XIV Local Electoral District of Mexico City",
-        "es": "XIV Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XIV Local Electoral District of Mexico City",
+        "lang:es": "XIV Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XV Local Electoral District of Mexico City",
-        "es": "XV Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XV Local Electoral District of Mexico City",
+        "lang:es": "XV Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XVI Local Electoral District of Mexico City",
-        "es": "XVI Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XVI Local Electoral District of Mexico City",
+        "lang:es": "XVI Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XVII Local Electoral District of Mexico City",
-        "es": "XVII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XVII Local Electoral District of Mexico City",
+        "lang:es": "XVII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Mexico City",
-        "es": "XVIII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XVIII Local Electoral District of Mexico City",
+        "lang:es": "XVIII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XIX Local Electoral District of Mexico City",
-        "es": "XIX Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XIX Local Electoral District of Mexico City",
+        "lang:es": "XIX Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XX Local Electoral District of Mexico City",
-        "es": "XX Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XX Local Electoral District of Mexico City",
+        "lang:es": "XX Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXI Local Electoral District of Mexico City",
-        "es": "XXI Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXI Local Electoral District of Mexico City",
+        "lang:es": "XXI Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -553,8 +553,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXII Local Electoral District of Mexico City",
-        "es": "XXII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXII Local Electoral District of Mexico City",
+        "lang:es": "XXII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -577,8 +577,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXIII Local Electoral District of Mexico City",
-        "es": "XXIII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXIII Local Electoral District of Mexico City",
+        "lang:es": "XXIII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -601,8 +601,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXIV Local Electoral District of Mexico City",
-        "es": "XXIV Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXIV Local Electoral District of Mexico City",
+        "lang:es": "XXIV Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -625,8 +625,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXV Local Electoral District of Mexico City",
-        "es": "XXV Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXV Local Electoral District of Mexico City",
+        "lang:es": "XXV Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -649,8 +649,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXVI Local Electoral District of Mexico City",
-        "es": "XXVI Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXVI Local Electoral District of Mexico City",
+        "lang:es": "XXVI Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -673,8 +673,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXVII Local Electoral District of Mexico City",
-        "es": "XXVII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXVII Local Electoral District of Mexico City",
+        "lang:es": "XXVII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -697,8 +697,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXVIII Local Electoral District of Mexico City",
-        "es": "XXVIII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXVIII Local Electoral District of Mexico City",
+        "lang:es": "XXVIII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -721,8 +721,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXIX Local Electoral District of Mexico City",
-        "es": "XXIX Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXIX Local Electoral District of Mexico City",
+        "lang:es": "XXIX Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -745,8 +745,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXX Local Electoral District of Mexico City",
-        "es": "XXX Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXX Local Electoral District of Mexico City",
+        "lang:es": "XXX Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -769,8 +769,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXXI Local Electoral District of Mexico City",
-        "es": "XXXI Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXXI Local Electoral District of Mexico City",
+        "lang:es": "XXXI Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -793,8 +793,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXXII Local Electoral District of Mexico City",
-        "es": "XXXII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXXII Local Electoral District of Mexico City",
+        "lang:es": "XXXII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },
@@ -817,8 +817,8 @@
         "lang:en": "local electoral district of Mexico City"
       },
       "name": {
-        "en": "XXXIII Local Electoral District of Mexico City",
-        "es": "XXXIII Distrito Electoral Local de Ciudad de México"
+        "lang:en": "XXXIII Local Electoral District of Mexico City",
+        "lang:es": "XXXIII Distrito Electoral Local de Ciudad de México"
       },
       "parent_id": "Q1489"
     },

--- a/legislative/Q28924553/Q53546059/popolo-m17n.json
+++ b/legislative/Q28924553/Q53546059/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "I Local Electoral District of Hidalgo",
-        "es": "I Distrito Electoral Local de Hidalgo"
+        "lang:en": "I Local Electoral District of Hidalgo",
+        "lang:es": "I Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "II Local Electoral District of Hidalgo",
-        "es": "II Distrito Electoral Local de Hidalgo"
+        "lang:en": "II Local Electoral District of Hidalgo",
+        "lang:es": "II Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "III Local Electoral District of Hidalgo",
-        "es": "III Distrito Electoral Local de Hidalgo"
+        "lang:en": "III Local Electoral District of Hidalgo",
+        "lang:es": "III Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "IV Local Electoral District of Hidalgo",
-        "es": "IV Distrito Electoral Local de Hidalgo"
+        "lang:en": "IV Local Electoral District of Hidalgo",
+        "lang:es": "IV Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "V Local Electoral District of Hidalgo",
-        "es": "V Distrito Electoral Local de Hidalgo"
+        "lang:en": "V Local Electoral District of Hidalgo",
+        "lang:es": "V Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "VI Local Electoral District of Hidalgo",
-        "es": "VI Distrito Electoral Local de Hidalgo"
+        "lang:en": "VI Local Electoral District of Hidalgo",
+        "lang:es": "VI Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "VII Local Electoral District of Hidalgo",
-        "es": "VII Distrito Electoral Local de Hidalgo"
+        "lang:en": "VII Local Electoral District of Hidalgo",
+        "lang:es": "VII Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "VIII Local Electoral District of Hidalgo",
-        "es": "VIII Distrito Electoral Local de Hidalgo"
+        "lang:en": "VIII Local Electoral District of Hidalgo",
+        "lang:es": "VIII Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "IX Local Electoral District of Hidalgo",
-        "es": "IX Distrito Electoral Local de Hidalgo"
+        "lang:en": "IX Local Electoral District of Hidalgo",
+        "lang:es": "IX Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "X Local Electoral District of Hidalgo",
-        "es": "X Distrito Electoral Local de Hidalgo"
+        "lang:en": "X Local Electoral District of Hidalgo",
+        "lang:es": "X Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "XI Local Electoral District of Hidalgo",
-        "es": "XI Distrito Electoral Local de Hidalgo"
+        "lang:en": "XI Local Electoral District of Hidalgo",
+        "lang:es": "XI Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "XII Local Electoral District of Hidalgo",
-        "es": "XII Distrito Electoral Local de Hidalgo"
+        "lang:en": "XII Local Electoral District of Hidalgo",
+        "lang:es": "XII Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "XIII Local Electoral District of Hidalgo",
-        "es": "XIII Distrito Electoral Local de Hidalgo"
+        "lang:en": "XIII Local Electoral District of Hidalgo",
+        "lang:es": "XIII Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "XIV Local Electoral District of Hidalgo",
-        "es": "XIV Distrito Electoral Local de Hidalgo"
+        "lang:en": "XIV Local Electoral District of Hidalgo",
+        "lang:es": "XIV Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "XV Local Electoral District of Hidalgo",
-        "es": "XV Distrito Electoral Local de Hidalgo"
+        "lang:en": "XV Local Electoral District of Hidalgo",
+        "lang:es": "XV Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "XVI Local Electoral District of Hidalgo",
-        "es": "XVI Distrito Electoral Local de Hidalgo"
+        "lang:en": "XVI Local Electoral District of Hidalgo",
+        "lang:es": "XVI Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "XVII Local Electoral District of Hidalgo",
-        "es": "XVII Distrito Electoral Local de Hidalgo"
+        "lang:en": "XVII Local Electoral District of Hidalgo",
+        "lang:es": "XVII Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Hidalgo"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Hidalgo",
-        "es": "XVIII Distrito Electoral Local de Hidalgo"
+        "lang:en": "XVIII Local Electoral District of Hidalgo",
+        "lang:es": "XVIII Distrito Electoral Local de Hidalgo"
       },
       "parent_id": "Q80903"
     },

--- a/legislative/Q5160856/Q53546030/popolo-m17n.json
+++ b/legislative/Q5160856/Q53546030/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "I Local Electoral District of Baja California",
-        "es": "I Distrito Electoral Local de Baja California"
+        "lang:en": "I Local Electoral District of Baja California",
+        "lang:es": "I Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "II Local Electoral District of Baja California",
-        "es": "II Distrito Electoral Local de Baja California"
+        "lang:en": "II Local Electoral District of Baja California",
+        "lang:es": "II Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "III Local Electoral District of Baja California",
-        "es": "III Distrito Electoral Local de Baja California"
+        "lang:en": "III Local Electoral District of Baja California",
+        "lang:es": "III Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "IV Local Electoral District of Baja California",
-        "es": "IV Distrito Electoral Local de Baja California"
+        "lang:en": "IV Local Electoral District of Baja California",
+        "lang:es": "IV Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "V Local Electoral District of Baja California",
-        "es": "V Distrito Electoral Local de Baja California"
+        "lang:en": "V Local Electoral District of Baja California",
+        "lang:es": "V Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "VI Local Electoral District of Baja California",
-        "es": "VI Distrito Electoral Local de Baja California"
+        "lang:en": "VI Local Electoral District of Baja California",
+        "lang:es": "VI Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "VII Local Electoral District of Baja California",
-        "es": "VII Distrito Electoral Local de Baja California"
+        "lang:en": "VII Local Electoral District of Baja California",
+        "lang:es": "VII Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "VIII Local Electoral District of Baja California",
-        "es": "VIII Distrito Electoral Local de Baja California"
+        "lang:en": "VIII Local Electoral District of Baja California",
+        "lang:es": "VIII Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "IX Local Electoral District of Baja California",
-        "es": "IX Distrito Electoral Local de Baja California"
+        "lang:en": "IX Local Electoral District of Baja California",
+        "lang:es": "IX Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "X Local Electoral District of Baja California",
-        "es": "X Distrito Electoral Local de Baja California"
+        "lang:en": "X Local Electoral District of Baja California",
+        "lang:es": "X Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "XI Local Electoral District of Baja California",
-        "es": "XI Distrito Electoral Local de Baja California"
+        "lang:en": "XI Local Electoral District of Baja California",
+        "lang:es": "XI Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "XII Local Electoral District of Baja California",
-        "es": "XII Distrito Electoral Local de Baja California"
+        "lang:en": "XII Local Electoral District of Baja California",
+        "lang:es": "XII Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "XIII Local Electoral District of Baja California",
-        "es": "XIII Distrito Electoral Local de Baja California"
+        "lang:en": "XIII Local Electoral District of Baja California",
+        "lang:es": "XIII Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "XIV Local Electoral District of Baja California",
-        "es": "XIV Distrito Electoral Local de Baja California"
+        "lang:en": "XIV Local Electoral District of Baja California",
+        "lang:es": "XIV Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "XV Local Electoral District of Baja California",
-        "es": "XV Distrito Electoral Local de Baja California"
+        "lang:en": "XV Local Electoral District of Baja California",
+        "lang:es": "XV Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "XVI Local Electoral District of Baja California",
-        "es": "XVI Distrito Electoral Local de Baja California"
+        "lang:en": "XVI Local Electoral District of Baja California",
+        "lang:es": "XVI Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Baja California"
       },
       "name": {
-        "en": "XVII Local Electoral District of Baja California",
-        "es": "XVII Distrito Electoral Local de Baja California"
+        "lang:en": "XVII Local Electoral District of Baja California",
+        "lang:es": "XVII Distrito Electoral Local de Baja California"
       },
       "parent_id": "Q58731"
     },

--- a/legislative/Q5160858/Q53546037/popolo-m17n.json
+++ b/legislative/Q5160858/Q53546037/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "I Local Electoral District of Chiapas",
-        "es": "I Distrito Electoral Local de Chiapas"
+        "lang:en": "I Local Electoral District of Chiapas",
+        "lang:es": "I Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "II Local Electoral District of Chiapas",
-        "es": "II Distrito Electoral Local de Chiapas"
+        "lang:en": "II Local Electoral District of Chiapas",
+        "lang:es": "II Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "III Local Electoral District of Chiapas",
-        "es": "III Distrito Electoral Local de Chiapas"
+        "lang:en": "III Local Electoral District of Chiapas",
+        "lang:es": "III Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "IV Local Electoral District of Chiapas",
-        "es": "IV Distrito Electoral Local de Chiapas"
+        "lang:en": "IV Local Electoral District of Chiapas",
+        "lang:es": "IV Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "V Local Electoral District of Chiapas",
-        "es": "V Distrito Electoral Local de Chiapas"
+        "lang:en": "V Local Electoral District of Chiapas",
+        "lang:es": "V Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "VI Local Electoral District of Chiapas",
-        "es": "VI Distrito Electoral Local de Chiapas"
+        "lang:en": "VI Local Electoral District of Chiapas",
+        "lang:es": "VI Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "VII Local Electoral District of Chiapas",
-        "es": "VII Distrito Electoral Local de Chiapas"
+        "lang:en": "VII Local Electoral District of Chiapas",
+        "lang:es": "VII Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "VIII Local Electoral District of Chiapas",
-        "es": "VIII Distrito Electoral Local de Chiapas"
+        "lang:en": "VIII Local Electoral District of Chiapas",
+        "lang:es": "VIII Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "IX Local Electoral District of Chiapas",
-        "es": "IX Distrito Electoral Local de Chiapas"
+        "lang:en": "IX Local Electoral District of Chiapas",
+        "lang:es": "IX Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "X Local Electoral District of Chiapas",
-        "es": "X Distrito Electoral Local de Chiapas"
+        "lang:en": "X Local Electoral District of Chiapas",
+        "lang:es": "X Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XI Local Electoral District of Chiapas",
-        "es": "XI Distrito Electoral Local de Chiapas"
+        "lang:en": "XI Local Electoral District of Chiapas",
+        "lang:es": "XI Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XII Local Electoral District of Chiapas",
-        "es": "XII Distrito Electoral Local de Chiapas"
+        "lang:en": "XII Local Electoral District of Chiapas",
+        "lang:es": "XII Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XIII Local Electoral District of Chiapas",
-        "es": "XIII Distrito Electoral Local de Chiapas"
+        "lang:en": "XIII Local Electoral District of Chiapas",
+        "lang:es": "XIII Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XIV Local Electoral District of Chiapas",
-        "es": "XIV Distrito Electoral Local de Chiapas"
+        "lang:en": "XIV Local Electoral District of Chiapas",
+        "lang:es": "XIV Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XV Local Electoral District of Chiapas",
-        "es": "XV Distrito Electoral Local de Chiapas"
+        "lang:en": "XV Local Electoral District of Chiapas",
+        "lang:es": "XV Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XVI Local Electoral District of Chiapas",
-        "es": "XVI Distrito Electoral Local de Chiapas"
+        "lang:en": "XVI Local Electoral District of Chiapas",
+        "lang:es": "XVI Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XVII Local Electoral District of Chiapas",
-        "es": "XVII Distrito Electoral Local de Chiapas"
+        "lang:en": "XVII Local Electoral District of Chiapas",
+        "lang:es": "XVII Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Chiapas",
-        "es": "XVIII Distrito Electoral Local de Chiapas"
+        "lang:en": "XVIII Local Electoral District of Chiapas",
+        "lang:es": "XVIII Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XIX Local Electoral District of Chiapas",
-        "es": "XIX Distrito Electoral Local de Chiapas"
+        "lang:en": "XIX Local Electoral District of Chiapas",
+        "lang:es": "XIX Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XX Local Electoral District of Chiapas",
-        "es": "XX Distrito Electoral Local de Chiapas"
+        "lang:en": "XX Local Electoral District of Chiapas",
+        "lang:es": "XX Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XXI Local Electoral District of Chiapas",
-        "es": "XXI Distrito Electoral Local de Chiapas"
+        "lang:en": "XXI Local Electoral District of Chiapas",
+        "lang:es": "XXI Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XXII Local Electoral District of Chiapas",
-        "es": "XXII Distrito Electoral Local de Chiapas"
+        "lang:en": "XXII Local Electoral District of Chiapas",
+        "lang:es": "XXII Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -553,8 +553,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XXIII Local Electoral District of Chiapas",
-        "es": "XXIII Distrito Electoral Local de Chiapas"
+        "lang:en": "XXIII Local Electoral District of Chiapas",
+        "lang:es": "XXIII Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },
@@ -577,8 +577,8 @@
         "lang:en": "local electoral district of Chiapas"
       },
       "name": {
-        "en": "XXIV Local Electoral District of Chiapas",
-        "es": "XXIV Distrito Electoral Local de Chiapas"
+        "lang:en": "XXIV Local Electoral District of Chiapas",
+        "lang:es": "XXIV Distrito Electoral Local de Chiapas"
       },
       "parent_id": "Q60123"
     },

--- a/legislative/Q5160860/Q53546032/popolo-m17n.json
+++ b/legislative/Q5160860/Q53546032/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "I Local Electoral District of Campeche",
-        "es": "I Distrito Electoral Local de Campeche"
+        "lang:en": "I Local Electoral District of Campeche",
+        "lang:es": "I Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "II Local Electoral District of Campeche",
-        "es": "II Distrito Electoral Local de Campeche"
+        "lang:en": "II Local Electoral District of Campeche",
+        "lang:es": "II Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "III Local Electoral District of Campeche",
-        "es": "III Distrito Electoral Local de Campeche"
+        "lang:en": "III Local Electoral District of Campeche",
+        "lang:es": "III Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "IV Local Electoral District of Campeche",
-        "es": "IV Distrito Electoral Local de Campeche"
+        "lang:en": "IV Local Electoral District of Campeche",
+        "lang:es": "IV Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "V Local Electoral District of Campeche",
-        "es": "V Distrito Electoral Local de Campeche"
+        "lang:en": "V Local Electoral District of Campeche",
+        "lang:es": "V Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "VI Local Electoral District of Campeche",
-        "es": "VI Distrito Electoral Local de Campeche"
+        "lang:en": "VI Local Electoral District of Campeche",
+        "lang:es": "VI Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "VII Local Electoral District of Campeche",
-        "es": "VII Distrito Electoral Local de Campeche"
+        "lang:en": "VII Local Electoral District of Campeche",
+        "lang:es": "VII Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "VIII Local Electoral District of Campeche",
-        "es": "VIII Distrito Electoral Local de Campeche"
+        "lang:en": "VIII Local Electoral District of Campeche",
+        "lang:es": "VIII Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "IX Local Electoral District of Campeche",
-        "es": "IX Distrito Electoral Local de Campeche"
+        "lang:en": "IX Local Electoral District of Campeche",
+        "lang:es": "IX Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "X Local Electoral District of Campeche",
-        "es": "X Distrito Electoral Local de Campeche"
+        "lang:en": "X Local Electoral District of Campeche",
+        "lang:es": "X Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XI Local Electoral District of Campeche",
-        "es": "XI Distrito Electoral Local de Campeche"
+        "lang:en": "XI Local Electoral District of Campeche",
+        "lang:es": "XI Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XII Local Electoral District of Campeche",
-        "es": "XII Distrito Electoral Local de Campeche"
+        "lang:en": "XII Local Electoral District of Campeche",
+        "lang:es": "XII Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XIII Local Electoral District of Campeche",
-        "es": "XIII Distrito Electoral Local de Campeche"
+        "lang:en": "XIII Local Electoral District of Campeche",
+        "lang:es": "XIII Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XIV Local Electoral District of Campeche",
-        "es": "XIV Distrito Electoral Local de Campeche"
+        "lang:en": "XIV Local Electoral District of Campeche",
+        "lang:es": "XIV Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XV Local Electoral District of Campeche",
-        "es": "XV Distrito Electoral Local de Campeche"
+        "lang:en": "XV Local Electoral District of Campeche",
+        "lang:es": "XV Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XVI Local Electoral District of Campeche",
-        "es": "XVI Distrito Electoral Local de Campeche"
+        "lang:en": "XVI Local Electoral District of Campeche",
+        "lang:es": "XVI Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XVII Local Electoral District of Campeche",
-        "es": "XVII Distrito Electoral Local de Campeche"
+        "lang:en": "XVII Local Electoral District of Campeche",
+        "lang:es": "XVII Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Campeche",
-        "es": "XVIII Distrito Electoral Local de Campeche"
+        "lang:en": "XVIII Local Electoral District of Campeche",
+        "lang:es": "XVIII Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XIX Local Electoral District of Campeche",
-        "es": "XIX Distrito Electoral Local de Campeche"
+        "lang:en": "XIX Local Electoral District of Campeche",
+        "lang:es": "XIX Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XX Local Electoral District of Campeche",
-        "es": "XX Distrito Electoral Local de Campeche"
+        "lang:en": "XX Local Electoral District of Campeche",
+        "lang:es": "XX Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Campeche"
       },
       "name": {
-        "en": "XXI Local Electoral District of Campeche",
-        "es": "XXI Distrito Electoral Local de Campeche"
+        "lang:en": "XXI Local Electoral District of Campeche",
+        "lang:es": "XXI Distrito Electoral Local de Campeche"
       },
       "parent_id": "Q80908"
     },

--- a/legislative/Q5160861/Q53546035/popolo-m17n.json
+++ b/legislative/Q5160861/Q53546035/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "I Local Electoral District of Coahuila",
-        "es": "I Distrito Electoral Local de Coahuila"
+        "lang:en": "I Local Electoral District of Coahuila",
+        "lang:es": "I Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "II Local Electoral District of Coahuila",
-        "es": "II Distrito Electoral Local de Coahuila"
+        "lang:en": "II Local Electoral District of Coahuila",
+        "lang:es": "II Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "III Local Electoral District of Coahuila",
-        "es": "III Distrito Electoral Local de Coahuila"
+        "lang:en": "III Local Electoral District of Coahuila",
+        "lang:es": "III Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "IV Local Electoral District of Coahuila",
-        "es": "IV Distrito Electoral Local de Coahuila"
+        "lang:en": "IV Local Electoral District of Coahuila",
+        "lang:es": "IV Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "V Local Electoral District of Coahuila",
-        "es": "V Distrito Electoral Local de Coahuila"
+        "lang:en": "V Local Electoral District of Coahuila",
+        "lang:es": "V Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "VI Local Electoral District of Coahuila",
-        "es": "VI Distrito Electoral Local de Coahuila"
+        "lang:en": "VI Local Electoral District of Coahuila",
+        "lang:es": "VI Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "VII Local Electoral District of Coahuila",
-        "es": "VII Distrito Electoral Local de Coahuila"
+        "lang:en": "VII Local Electoral District of Coahuila",
+        "lang:es": "VII Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "VIII Local Electoral District of Coahuila",
-        "es": "VIII Distrito Electoral Local de Coahuila"
+        "lang:en": "VIII Local Electoral District of Coahuila",
+        "lang:es": "VIII Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "IX Local Electoral District of Coahuila",
-        "es": "IX Distrito Electoral Local de Coahuila"
+        "lang:en": "IX Local Electoral District of Coahuila",
+        "lang:es": "IX Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "X Local Electoral District of Coahuila",
-        "es": "X Distrito Electoral Local de Coahuila"
+        "lang:en": "X Local Electoral District of Coahuila",
+        "lang:es": "X Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "XI Local Electoral District of Coahuila",
-        "es": "XI Distrito Electoral Local de Coahuila"
+        "lang:en": "XI Local Electoral District of Coahuila",
+        "lang:es": "XI Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "XII Local Electoral District of Coahuila",
-        "es": "XII Distrito Electoral Local de Coahuila"
+        "lang:en": "XII Local Electoral District of Coahuila",
+        "lang:es": "XII Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "XIII Local Electoral District of Coahuila",
-        "es": "XIII Distrito Electoral Local de Coahuila"
+        "lang:en": "XIII Local Electoral District of Coahuila",
+        "lang:es": "XIII Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "XIV Local Electoral District of Coahuila",
-        "es": "XIV Distrito Electoral Local de Coahuila"
+        "lang:en": "XIV Local Electoral District of Coahuila",
+        "lang:es": "XIV Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "XV Local Electoral District of Coahuila",
-        "es": "XV Distrito Electoral Local de Coahuila"
+        "lang:en": "XV Local Electoral District of Coahuila",
+        "lang:es": "XV Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Coahuila"
       },
       "name": {
-        "en": "XVI Local Electoral District of Coahuila",
-        "es": "XVI Distrito Electoral Local de Coahuila"
+        "lang:en": "XVI Local Electoral District of Coahuila",
+        "lang:es": "XVI Distrito Electoral Local de Coahuila"
       },
       "parent_id": "Q53079"
     },

--- a/legislative/Q5160862/Q53546036/popolo-m17n.json
+++ b/legislative/Q5160862/Q53546036/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "I Local Electoral District of Colima",
-        "es": "I Distrito Electoral Local de Colima"
+        "lang:en": "I Local Electoral District of Colima",
+        "lang:es": "I Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "II Local Electoral District of Colima",
-        "es": "II Distrito Electoral Local de Colima"
+        "lang:en": "II Local Electoral District of Colima",
+        "lang:es": "II Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "III Local Electoral District of Colima",
-        "es": "III Distrito Electoral Local de Colima"
+        "lang:en": "III Local Electoral District of Colima",
+        "lang:es": "III Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "IV Local Electoral District of Colima",
-        "es": "IV Distrito Electoral Local de Colima"
+        "lang:en": "IV Local Electoral District of Colima",
+        "lang:es": "IV Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "V Local Electoral District of Colima",
-        "es": "V Distrito Electoral Local de Colima"
+        "lang:en": "V Local Electoral District of Colima",
+        "lang:es": "V Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "VI Local Electoral District of Colima",
-        "es": "VI Distrito Electoral Local de Colima"
+        "lang:en": "VI Local Electoral District of Colima",
+        "lang:es": "VI Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "VII Local Electoral District of Colima",
-        "es": "VII Distrito Electoral Local de Colima"
+        "lang:en": "VII Local Electoral District of Colima",
+        "lang:es": "VII Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "VIII Local Electoral District of Colima",
-        "es": "VIII Distrito Electoral Local de Colima"
+        "lang:en": "VIII Local Electoral District of Colima",
+        "lang:es": "VIII Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "IX Local Electoral District of Colima",
-        "es": "IX Distrito Electoral Local de Colima"
+        "lang:en": "IX Local Electoral District of Colima",
+        "lang:es": "IX Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "X Local Electoral District of Colima",
-        "es": "X Distrito Electoral Local de Colima"
+        "lang:en": "X Local Electoral District of Colima",
+        "lang:es": "X Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "XI Local Electoral District of Colima",
-        "es": "XI Distrito Electoral Local de Colima"
+        "lang:en": "XI Local Electoral District of Colima",
+        "lang:es": "XI Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "XII Local Electoral District of Colima",
-        "es": "XII Distrito Electoral Local de Colima"
+        "lang:en": "XII Local Electoral District of Colima",
+        "lang:es": "XII Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "XIII Local Electoral District of Colima",
-        "es": "XIII Distrito Electoral Local de Colima"
+        "lang:en": "XIII Local Electoral District of Colima",
+        "lang:es": "XIII Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "XIV Local Electoral District of Colima",
-        "es": "XIV Distrito Electoral Local de Colima"
+        "lang:en": "XIV Local Electoral District of Colima",
+        "lang:es": "XIV Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "XV Local Electoral District of Colima",
-        "es": "XV Distrito Electoral Local de Colima"
+        "lang:en": "XV Local Electoral District of Colima",
+        "lang:es": "XV Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Colima"
       },
       "name": {
-        "en": "XVI Local Electoral District of Colima",
-        "es": "XVI Distrito Electoral Local de Colima"
+        "lang:en": "XVI Local Electoral District of Colima",
+        "lang:es": "XVI Distrito Electoral Local de Colima"
       },
       "parent_id": "Q61309"
     },

--- a/legislative/Q5160871/Q53546057/popolo-m17n.json
+++ b/legislative/Q5160871/Q53546057/popolo-m17n.json
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "I Local Electoral District of Guanajuato",
-        "es": "I Distrito Electoral Local de Guanajuato"
+        "lang:en": "I Local Electoral District of Guanajuato",
+        "lang:es": "I Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "II Local Electoral District of Guanajuato",
-        "es": "II Distrito Electoral Local de Guanajuato"
+        "lang:en": "II Local Electoral District of Guanajuato",
+        "lang:es": "II Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "III Local Electoral District of Guanajuato",
-        "es": "III Distrito Electoral Local de Guanajuato"
+        "lang:en": "III Local Electoral District of Guanajuato",
+        "lang:es": "III Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "IV Local Electoral District of Guanajuato",
-        "es": "IV Distrito Electoral Local de Guanajuato"
+        "lang:en": "IV Local Electoral District of Guanajuato",
+        "lang:es": "IV Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "V Local Electoral District of Guanajuato",
-        "es": "V Distrito Electoral Local de Guanajuato"
+        "lang:en": "V Local Electoral District of Guanajuato",
+        "lang:es": "V Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "VI Local Electoral District of Guanajuato",
-        "es": "VI Distrito Electoral Local de Guanajuato"
+        "lang:en": "VI Local Electoral District of Guanajuato",
+        "lang:es": "VI Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "VII Local Electoral District of Guanajuato",
-        "es": "VII Distrito Electoral Local de Guanajuato"
+        "lang:en": "VII Local Electoral District of Guanajuato",
+        "lang:es": "VII Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "VIII Local Electoral District of Guanajuato",
-        "es": "VIII Distrito Electoral Local de Guanajuato"
+        "lang:en": "VIII Local Electoral District of Guanajuato",
+        "lang:es": "VIII Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "IX Local Electoral District of Guanajuato",
-        "es": "IX Distrito Electoral Local de Guanajuato"
+        "lang:en": "IX Local Electoral District of Guanajuato",
+        "lang:es": "IX Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "X Local Electoral District of Guanajuato",
-        "es": "X Distrito Electoral Local de Guanajuato"
+        "lang:en": "X Local Electoral District of Guanajuato",
+        "lang:es": "X Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XI Local Electoral District of Guanajuato",
-        "es": "XI Distrito Electoral Local de Guanajuato"
+        "lang:en": "XI Local Electoral District of Guanajuato",
+        "lang:es": "XI Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XII Local Electoral District of Guanajuato",
-        "es": "XII Distrito Electoral Local de Guanajuato"
+        "lang:en": "XII Local Electoral District of Guanajuato",
+        "lang:es": "XII Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XIII Local Electoral District of Guanajuato",
-        "es": "XIII Distrito Electoral Local de Guanajuato"
+        "lang:en": "XIII Local Electoral District of Guanajuato",
+        "lang:es": "XIII Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XIV Local Electoral District of Guanajuato",
-        "es": "XIV Distrito Electoral Local de Guanajuato"
+        "lang:en": "XIV Local Electoral District of Guanajuato",
+        "lang:es": "XIV Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XV Local Electoral District of Guanajuato",
-        "es": "XV Distrito Electoral Local de Guanajuato"
+        "lang:en": "XV Local Electoral District of Guanajuato",
+        "lang:es": "XV Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XVI Local Electoral District of Guanajuato",
-        "es": "XVI Distrito Electoral Local de Guanajuato"
+        "lang:en": "XVI Local Electoral District of Guanajuato",
+        "lang:es": "XVI Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XVII Local Electoral District of Guanajuato",
-        "es": "XVII Distrito Electoral Local de Guanajuato"
+        "lang:en": "XVII Local Electoral District of Guanajuato",
+        "lang:es": "XVII Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Guanajuato",
-        "es": "XVIII Distrito Electoral Local de Guanajuato"
+        "lang:en": "XVIII Local Electoral District of Guanajuato",
+        "lang:es": "XVIII Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XIX Local Electoral District of Guanajuato",
-        "es": "XIX Distrito Electoral Local de Guanajuato"
+        "lang:en": "XIX Local Electoral District of Guanajuato",
+        "lang:es": "XIX Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XX Local Electoral District of Guanajuato",
-        "es": "XX Distrito Electoral Local de Guanajuato"
+        "lang:en": "XX Local Electoral District of Guanajuato",
+        "lang:es": "XX Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XXI Local Electoral District of Guanajuato",
-        "es": "XXI Distrito Electoral Local de Guanajuato"
+        "lang:en": "XXI Local Electoral District of Guanajuato",
+        "lang:es": "XXI Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },
@@ -553,8 +553,8 @@
         "lang:en": "local electoral district of Guanajuato"
       },
       "name": {
-        "en": "XXII Local Electoral District of Guanajuato",
-        "es": "XXII Distrito Electoral Local de Guanajuato"
+        "lang:en": "XXII Local Electoral District of Guanajuato",
+        "lang:es": "XXII Distrito Electoral Local de Guanajuato"
       },
       "parent_id": "Q46475"
     },

--- a/legislative/Q5160874/Q53546060/popolo-m17n.json
+++ b/legislative/Q5160874/Q53546060/popolo-m17n.json
@@ -98,8 +98,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "I Local Electoral District of Jalisco",
-        "es": "I Distrito Electoral Local de Jalisco"
+        "lang:en": "I Local Electoral District of Jalisco",
+        "lang:es": "I Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -122,8 +122,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "II Local Electoral District of Jalisco",
-        "es": "II Distrito Electoral Local de Jalisco"
+        "lang:en": "II Local Electoral District of Jalisco",
+        "lang:es": "II Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -146,8 +146,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "III Local Electoral District of Jalisco",
-        "es": "III Distrito Electoral Local de Jalisco"
+        "lang:en": "III Local Electoral District of Jalisco",
+        "lang:es": "III Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -170,8 +170,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "IV Local Electoral District of Jalisco",
-        "es": "IV Distrito Electoral Local de Jalisco"
+        "lang:en": "IV Local Electoral District of Jalisco",
+        "lang:es": "IV Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -194,8 +194,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "V Local Electoral District of Jalisco",
-        "es": "V Distrito Electoral Local de Jalisco"
+        "lang:en": "V Local Electoral District of Jalisco",
+        "lang:es": "V Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -218,8 +218,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "VI Local Electoral District of Jalisco",
-        "es": "VI Distrito Electoral Local de Jalisco"
+        "lang:en": "VI Local Electoral District of Jalisco",
+        "lang:es": "VI Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -242,8 +242,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "VII Local Electoral District of Jalisco",
-        "es": "VII Distrito Electoral Local de Jalisco"
+        "lang:en": "VII Local Electoral District of Jalisco",
+        "lang:es": "VII Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -266,8 +266,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "VIII Local Electoral District of Jalisco",
-        "es": "VIII Distrito Electoral Local de Jalisco"
+        "lang:en": "VIII Local Electoral District of Jalisco",
+        "lang:es": "VIII Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -290,8 +290,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "IX Local Electoral District of Jalisco",
-        "es": "IX Distrito Electoral Local de Jalisco"
+        "lang:en": "IX Local Electoral District of Jalisco",
+        "lang:es": "IX Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -314,8 +314,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "X Local Electoral District of Jalisco",
-        "es": "X Distrito Electoral Local de Jalisco"
+        "lang:en": "X Local Electoral District of Jalisco",
+        "lang:es": "X Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -338,8 +338,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XI Local Electoral District of Jalisco",
-        "es": "XI Distrito Electoral Local de Jalisco"
+        "lang:en": "XI Local Electoral District of Jalisco",
+        "lang:es": "XI Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -362,8 +362,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XII Local Electoral District of Jalisco",
-        "es": "XII Distrito Electoral Local de Jalisco"
+        "lang:en": "XII Local Electoral District of Jalisco",
+        "lang:es": "XII Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -386,8 +386,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XIII Local Electoral District of Jalisco",
-        "es": "XIII Distrito Electoral Local de Jalisco"
+        "lang:en": "XIII Local Electoral District of Jalisco",
+        "lang:es": "XIII Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -410,8 +410,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XIV Local Electoral District of Jalisco",
-        "es": "XIV Distrito Electoral Local de Jalisco"
+        "lang:en": "XIV Local Electoral District of Jalisco",
+        "lang:es": "XIV Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -434,8 +434,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XV Local Electoral District of Jalisco",
-        "es": "XV Distrito Electoral Local de Jalisco"
+        "lang:en": "XV Local Electoral District of Jalisco",
+        "lang:es": "XV Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -458,8 +458,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XVI Local Electoral District of Jalisco",
-        "es": "XVI Distrito Electoral Local de Jalisco"
+        "lang:en": "XVI Local Electoral District of Jalisco",
+        "lang:es": "XVI Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -482,8 +482,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XVII Local Electoral District of Jalisco",
-        "es": "XVII Distrito Electoral Local de Jalisco"
+        "lang:en": "XVII Local Electoral District of Jalisco",
+        "lang:es": "XVII Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -506,8 +506,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Jalisco",
-        "es": "XVIII Distrito Electoral Local de Jalisco"
+        "lang:en": "XVIII Local Electoral District of Jalisco",
+        "lang:es": "XVIII Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -530,8 +530,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XIX Local Electoral District of Jalisco",
-        "es": "XIX Distrito Electoral Local de Jalisco"
+        "lang:en": "XIX Local Electoral District of Jalisco",
+        "lang:es": "XIX Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },
@@ -554,8 +554,8 @@
         "lang:en": "local electoral district of Jalisco"
       },
       "name": {
-        "en": "XX Local Electoral District of Jalisco",
-        "es": "XX Distrito Electoral Local de Jalisco"
+        "lang:en": "XX Local Electoral District of Jalisco",
+        "lang:es": "XX Distrito Electoral Local de Jalisco"
       },
       "parent_id": "Q13160"
     },

--- a/legislative/Q5160879/Q53546062/popolo-m17n.json
+++ b/legislative/Q5160879/Q53546062/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "I Local Electoral District of Michoacan",
-        "es": "I Distrito Electoral Local de Michoacan"
+        "lang:en": "I Local Electoral District of Michoacan",
+        "lang:es": "I Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "II Local Electoral District of Michoacan",
-        "es": "II Distrito Electoral Local de Michoacan"
+        "lang:en": "II Local Electoral District of Michoacan",
+        "lang:es": "II Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "III Local Electoral District of Michoacan",
-        "es": "III Distrito Electoral Local de Michoacan"
+        "lang:en": "III Local Electoral District of Michoacan",
+        "lang:es": "III Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "IV Local Electoral District of Michoacan",
-        "es": "IV Distrito Electoral Local de Michoacan"
+        "lang:en": "IV Local Electoral District of Michoacan",
+        "lang:es": "IV Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "V Local Electoral District of Michoacan",
-        "es": "V Distrito Electoral Local de Michoacan"
+        "lang:en": "V Local Electoral District of Michoacan",
+        "lang:es": "V Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "VI Local Electoral District of Michoacan",
-        "es": "VI Distrito Electoral Local de Michoacan"
+        "lang:en": "VI Local Electoral District of Michoacan",
+        "lang:es": "VI Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "VII Local Electoral District of Michoacan",
-        "es": "VII Distrito Electoral Local de Michoacan"
+        "lang:en": "VII Local Electoral District of Michoacan",
+        "lang:es": "VII Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "VIII Local Electoral District of Michoacan",
-        "es": "VIII Distrito Electoral Local de Michoacan"
+        "lang:en": "VIII Local Electoral District of Michoacan",
+        "lang:es": "VIII Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "IX Local Electoral District of Michoacan",
-        "es": "IX Distrito Electoral Local de Michoacan"
+        "lang:en": "IX Local Electoral District of Michoacan",
+        "lang:es": "IX Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "X Local Electoral District of Michoacan",
-        "es": "X Distrito Electoral Local de Michoacan"
+        "lang:en": "X Local Electoral District of Michoacan",
+        "lang:es": "X Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XI Local Electoral District of Michoacan",
-        "es": "XI Distrito Electoral Local de Michoacan"
+        "lang:en": "XI Local Electoral District of Michoacan",
+        "lang:es": "XI Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XII Local Electoral District of Michoacan",
-        "es": "XII Distrito Electoral Local de Michoacan"
+        "lang:en": "XII Local Electoral District of Michoacan",
+        "lang:es": "XII Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XIII Local Electoral District of Michoacan",
-        "es": "XIII Distrito Electoral Local de Michoacan"
+        "lang:en": "XIII Local Electoral District of Michoacan",
+        "lang:es": "XIII Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XIV Local Electoral District of Michoacan",
-        "es": "XIV Distrito Electoral Local de Michoacan"
+        "lang:en": "XIV Local Electoral District of Michoacan",
+        "lang:es": "XIV Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XV Local Electoral District of Michoacan",
-        "es": "XV Distrito Electoral Local de Michoacan"
+        "lang:en": "XV Local Electoral District of Michoacan",
+        "lang:es": "XV Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XVI Local Electoral District of Michoacan",
-        "es": "XVI Distrito Electoral Local de Michoacan"
+        "lang:en": "XVI Local Electoral District of Michoacan",
+        "lang:es": "XVI Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XVII Local Electoral District of Michoacan",
-        "es": "XVII Distrito Electoral Local de Michoacan"
+        "lang:en": "XVII Local Electoral District of Michoacan",
+        "lang:es": "XVII Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Michoacan",
-        "es": "XVIII Distrito Electoral Local de Michoacan"
+        "lang:en": "XVIII Local Electoral District of Michoacan",
+        "lang:es": "XVIII Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XIX Local Electoral District of Michoacan",
-        "es": "XIX Distrito Electoral Local de Michoacan"
+        "lang:en": "XIX Local Electoral District of Michoacan",
+        "lang:es": "XIX Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XX Local Electoral District of Michoacan",
-        "es": "XX Distrito Electoral Local de Michoacan"
+        "lang:en": "XX Local Electoral District of Michoacan",
+        "lang:es": "XX Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XXI Local Electoral District of Michoacan",
-        "es": "XXI Distrito Electoral Local de Michoacan"
+        "lang:en": "XXI Local Electoral District of Michoacan",
+        "lang:es": "XXI Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XXII Local Electoral District of Michoacan",
-        "es": "XXII Distrito Electoral Local de Michoacan"
+        "lang:en": "XXII Local Electoral District of Michoacan",
+        "lang:es": "XXII Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -553,8 +553,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XXIII Local Electoral District of Michoacan",
-        "es": "XXIII Distrito Electoral Local de Michoacan"
+        "lang:en": "XXIII Local Electoral District of Michoacan",
+        "lang:es": "XXIII Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },
@@ -577,8 +577,8 @@
         "lang:en": "local electoral district of Michoacan"
       },
       "name": {
-        "en": "XXIV Local Electoral District of Michoacan",
-        "es": "XXIV Distrito Electoral Local de Michoacan"
+        "lang:en": "XXIV Local Electoral District of Michoacan",
+        "lang:es": "XXIV Distrito Electoral Local de Michoacan"
       },
       "parent_id": "Q79861"
     },

--- a/legislative/Q5160884/Q53546076/popolo-m17n.json
+++ b/legislative/Q5160884/Q53546076/popolo-m17n.json
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "I Local Electoral District of Oaxaca",
-        "es": "I Distrito Electoral Local de Oaxaca"
+        "lang:en": "I Local Electoral District of Oaxaca",
+        "lang:es": "I Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "II Local Electoral District of Oaxaca",
-        "es": "II Distrito Electoral Local de Oaxaca"
+        "lang:en": "II Local Electoral District of Oaxaca",
+        "lang:es": "II Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "III Local Electoral District of Oaxaca",
-        "es": "III Distrito Electoral Local de Oaxaca"
+        "lang:en": "III Local Electoral District of Oaxaca",
+        "lang:es": "III Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "IV Local Electoral District of Oaxaca",
-        "es": "IV Distrito Electoral Local de Oaxaca"
+        "lang:en": "IV Local Electoral District of Oaxaca",
+        "lang:es": "IV Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "V Local Electoral District of Oaxaca",
-        "es": "V Distrito Electoral Local de Oaxaca"
+        "lang:en": "V Local Electoral District of Oaxaca",
+        "lang:es": "V Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "VI Local Electoral District of Oaxaca",
-        "es": "VI Distrito Electoral Local de Oaxaca"
+        "lang:en": "VI Local Electoral District of Oaxaca",
+        "lang:es": "VI Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "VII Local Electoral District of Oaxaca",
-        "es": "VII Distrito Electoral Local de Oaxaca"
+        "lang:en": "VII Local Electoral District of Oaxaca",
+        "lang:es": "VII Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "VIII Local Electoral District of Oaxaca",
-        "es": "VIII Distrito Electoral Local de Oaxaca"
+        "lang:en": "VIII Local Electoral District of Oaxaca",
+        "lang:es": "VIII Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "IX Local Electoral District of Oaxaca",
-        "es": "IX Distrito Electoral Local de Oaxaca"
+        "lang:en": "IX Local Electoral District of Oaxaca",
+        "lang:es": "IX Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "X Local Electoral District of Oaxaca",
-        "es": "X Distrito Electoral Local de Oaxaca"
+        "lang:en": "X Local Electoral District of Oaxaca",
+        "lang:es": "X Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XI Local Electoral District of Oaxaca",
-        "es": "XI Distrito Electoral Local de Oaxaca"
+        "lang:en": "XI Local Electoral District of Oaxaca",
+        "lang:es": "XI Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XII Local Electoral District of Oaxaca",
-        "es": "XII Distrito Electoral Local de Oaxaca"
+        "lang:en": "XII Local Electoral District of Oaxaca",
+        "lang:es": "XII Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XIII Local Electoral District of Oaxaca",
-        "es": "XIII Distrito Electoral Local de Oaxaca"
+        "lang:en": "XIII Local Electoral District of Oaxaca",
+        "lang:es": "XIII Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XIV Local Electoral District of Oaxaca",
-        "es": "XIV Distrito Electoral Local de Oaxaca"
+        "lang:en": "XIV Local Electoral District of Oaxaca",
+        "lang:es": "XIV Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XV Local Electoral District of Oaxaca",
-        "es": "XV Distrito Electoral Local de Oaxaca"
+        "lang:en": "XV Local Electoral District of Oaxaca",
+        "lang:es": "XV Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XVI Local Electoral District of Oaxaca",
-        "es": "XVI Distrito Electoral Local de Oaxaca"
+        "lang:en": "XVI Local Electoral District of Oaxaca",
+        "lang:es": "XVI Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XVII Local Electoral District of Oaxaca",
-        "es": "XVII Distrito Electoral Local de Oaxaca"
+        "lang:en": "XVII Local Electoral District of Oaxaca",
+        "lang:es": "XVII Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Oaxaca",
-        "es": "XVIII Distrito Electoral Local de Oaxaca"
+        "lang:en": "XVIII Local Electoral District of Oaxaca",
+        "lang:es": "XVIII Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XIX Local Electoral District of Oaxaca",
-        "es": "XIX Distrito Electoral Local de Oaxaca"
+        "lang:en": "XIX Local Electoral District of Oaxaca",
+        "lang:es": "XIX Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XX Local Electoral District of Oaxaca",
-        "es": "XX Distrito Electoral Local de Oaxaca"
+        "lang:en": "XX Local Electoral District of Oaxaca",
+        "lang:es": "XX Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XXI Local Electoral District of Oaxaca",
-        "es": "XXI Distrito Electoral Local de Oaxaca"
+        "lang:en": "XXI Local Electoral District of Oaxaca",
+        "lang:es": "XXI Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -553,8 +553,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XXII Local Electoral District of Oaxaca",
-        "es": "XXII Distrito Electoral Local de Oaxaca"
+        "lang:en": "XXII Local Electoral District of Oaxaca",
+        "lang:es": "XXII Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -577,8 +577,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XXIII Local Electoral District of Oaxaca",
-        "es": "XXIII Distrito Electoral Local de Oaxaca"
+        "lang:en": "XXIII Local Electoral District of Oaxaca",
+        "lang:es": "XXIII Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -601,8 +601,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XXIV Local Electoral District of Oaxaca",
-        "es": "XXIV Distrito Electoral Local de Oaxaca"
+        "lang:en": "XXIV Local Electoral District of Oaxaca",
+        "lang:es": "XXIV Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },
@@ -625,8 +625,8 @@
         "lang:en": "local electoral district of Oaxaca"
       },
       "name": {
-        "en": "XXV Local Electoral District of Oaxaca",
-        "es": "XXV Distrito Electoral Local de Oaxaca"
+        "lang:en": "XXV Local Electoral District of Oaxaca",
+        "lang:es": "XXV Distrito Electoral Local de Oaxaca"
       },
       "parent_id": "Q34110"
     },

--- a/legislative/Q5160887/Q53546081/popolo-m17n.json
+++ b/legislative/Q5160887/Q53546081/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "I Local Electoral District of Puebla",
-        "es": "I Distrito Electoral Local de Puebla"
+        "lang:en": "I Local Electoral District of Puebla",
+        "lang:es": "I Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "II Local Electoral District of Puebla",
-        "es": "II Distrito Electoral Local de Puebla"
+        "lang:en": "II Local Electoral District of Puebla",
+        "lang:es": "II Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "III Local Electoral District of Puebla",
-        "es": "III Distrito Electoral Local de Puebla"
+        "lang:en": "III Local Electoral District of Puebla",
+        "lang:es": "III Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "IV Local Electoral District of Puebla",
-        "es": "IV Distrito Electoral Local de Puebla"
+        "lang:en": "IV Local Electoral District of Puebla",
+        "lang:es": "IV Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "V Local Electoral District of Puebla",
-        "es": "V Distrito Electoral Local de Puebla"
+        "lang:en": "V Local Electoral District of Puebla",
+        "lang:es": "V Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "VI Local Electoral District of Puebla",
-        "es": "VI Distrito Electoral Local de Puebla"
+        "lang:en": "VI Local Electoral District of Puebla",
+        "lang:es": "VI Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "VII Local Electoral District of Puebla",
-        "es": "VII Distrito Electoral Local de Puebla"
+        "lang:en": "VII Local Electoral District of Puebla",
+        "lang:es": "VII Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "VIII Local Electoral District of Puebla",
-        "es": "VIII Distrito Electoral Local de Puebla"
+        "lang:en": "VIII Local Electoral District of Puebla",
+        "lang:es": "VIII Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "IX Local Electoral District of Puebla",
-        "es": "IX Distrito Electoral Local de Puebla"
+        "lang:en": "IX Local Electoral District of Puebla",
+        "lang:es": "IX Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "X Local Electoral District of Puebla",
-        "es": "X Distrito Electoral Local de Puebla"
+        "lang:en": "X Local Electoral District of Puebla",
+        "lang:es": "X Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XI Local Electoral District of Puebla",
-        "es": "XI Distrito Electoral Local de Puebla"
+        "lang:en": "XI Local Electoral District of Puebla",
+        "lang:es": "XI Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XII Local Electoral District of Puebla",
-        "es": "XII Distrito Electoral Local de Puebla"
+        "lang:en": "XII Local Electoral District of Puebla",
+        "lang:es": "XII Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XIII Local Electoral District of Puebla",
-        "es": "XIII Distrito Electoral Local de Puebla"
+        "lang:en": "XIII Local Electoral District of Puebla",
+        "lang:es": "XIII Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XIV Local Electoral District of Puebla",
-        "es": "XIV Distrito Electoral Local de Puebla"
+        "lang:en": "XIV Local Electoral District of Puebla",
+        "lang:es": "XIV Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XV Local Electoral District of Puebla",
-        "es": "XV Distrito Electoral Local de Puebla"
+        "lang:en": "XV Local Electoral District of Puebla",
+        "lang:es": "XV Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XVI Local Electoral District of Puebla",
-        "es": "XVI Distrito Electoral Local de Puebla"
+        "lang:en": "XVI Local Electoral District of Puebla",
+        "lang:es": "XVI Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XVII Local Electoral District of Puebla",
-        "es": "XVII Distrito Electoral Local de Puebla"
+        "lang:en": "XVII Local Electoral District of Puebla",
+        "lang:es": "XVII Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Puebla",
-        "es": "XVIII Distrito Electoral Local de Puebla"
+        "lang:en": "XVIII Local Electoral District of Puebla",
+        "lang:es": "XVIII Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XIX Local Electoral District of Puebla",
-        "es": "XIX Distrito Electoral Local de Puebla"
+        "lang:en": "XIX Local Electoral District of Puebla",
+        "lang:es": "XIX Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XX Local Electoral District of Puebla",
-        "es": "XX Distrito Electoral Local de Puebla"
+        "lang:en": "XX Local Electoral District of Puebla",
+        "lang:es": "XX Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XXI Local Electoral District of Puebla",
-        "es": "XXI Distrito Electoral Local de Puebla"
+        "lang:en": "XXI Local Electoral District of Puebla",
+        "lang:es": "XXI Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XXII Local Electoral District of Puebla",
-        "es": "XXII Distrito Electoral Local de Puebla"
+        "lang:en": "XXII Local Electoral District of Puebla",
+        "lang:es": "XXII Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -553,8 +553,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XXIII Local Electoral District of Puebla",
-        "es": "XXIII Distrito Electoral Local de Puebla"
+        "lang:en": "XXIII Local Electoral District of Puebla",
+        "lang:es": "XXIII Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -577,8 +577,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XXIV Local Electoral District of Puebla",
-        "es": "XXIV Distrito Electoral Local de Puebla"
+        "lang:en": "XXIV Local Electoral District of Puebla",
+        "lang:es": "XXIV Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -601,8 +601,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XXV Local Electoral District of Puebla",
-        "es": "XXV Distrito Electoral Local de Puebla"
+        "lang:en": "XXV Local Electoral District of Puebla",
+        "lang:es": "XXV Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },
@@ -625,8 +625,8 @@
         "lang:en": "local electoral district of Puebla"
       },
       "name": {
-        "en": "XXVI Local Electoral District of Puebla",
-        "es": "XXVI Distrito Electoral Local de Puebla"
+        "lang:en": "XXVI Local Electoral District of Puebla",
+        "lang:es": "XXVI Distrito Electoral Local de Puebla"
       },
       "parent_id": "Q79923"
     },

--- a/legislative/Q5160888/Q53546085/popolo-m17n.json
+++ b/legislative/Q5160888/Q53546085/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "I Local Electoral District of Quintana Roo",
-        "es": "I Distrito Electoral Local de Quintana Roo"
+        "lang:en": "I Local Electoral District of Quintana Roo",
+        "lang:es": "I Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "II Local Electoral District of Quintana Roo",
-        "es": "II Distrito Electoral Local de Quintana Roo"
+        "lang:en": "II Local Electoral District of Quintana Roo",
+        "lang:es": "II Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "III Local Electoral District of Quintana Roo",
-        "es": "III Distrito Electoral Local de Quintana Roo"
+        "lang:en": "III Local Electoral District of Quintana Roo",
+        "lang:es": "III Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "IV Local Electoral District of Quintana Roo",
-        "es": "IV Distrito Electoral Local de Quintana Roo"
+        "lang:en": "IV Local Electoral District of Quintana Roo",
+        "lang:es": "IV Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "V Local Electoral District of Quintana Roo",
-        "es": "V Distrito Electoral Local de Quintana Roo"
+        "lang:en": "V Local Electoral District of Quintana Roo",
+        "lang:es": "V Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "VI Local Electoral District of Quintana Roo",
-        "es": "VI Distrito Electoral Local de Quintana Roo"
+        "lang:en": "VI Local Electoral District of Quintana Roo",
+        "lang:es": "VI Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "VII Local Electoral District of Quintana Roo",
-        "es": "VII Distrito Electoral Local de Quintana Roo"
+        "lang:en": "VII Local Electoral District of Quintana Roo",
+        "lang:es": "VII Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "VIII Local Electoral District of Quintana Roo",
-        "es": "VIII Distrito Electoral Local de Quintana Roo"
+        "lang:en": "VIII Local Electoral District of Quintana Roo",
+        "lang:es": "VIII Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "IX Local Electoral District of Quintana Roo",
-        "es": "IX Distrito Electoral Local de Quintana Roo"
+        "lang:en": "IX Local Electoral District of Quintana Roo",
+        "lang:es": "IX Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "X Local Electoral District of Quintana Roo",
-        "es": "X Distrito Electoral Local de Quintana Roo"
+        "lang:en": "X Local Electoral District of Quintana Roo",
+        "lang:es": "X Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "XI Local Electoral District of Quintana Roo",
-        "es": "XI Distrito Electoral Local de Quintana Roo"
+        "lang:en": "XI Local Electoral District of Quintana Roo",
+        "lang:es": "XI Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "XII Local Electoral District of Quintana Roo",
-        "es": "XII Distrito Electoral Local de Quintana Roo"
+        "lang:en": "XII Local Electoral District of Quintana Roo",
+        "lang:es": "XII Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "XIII Local Electoral District of Quintana Roo",
-        "es": "XIII Distrito Electoral Local de Quintana Roo"
+        "lang:en": "XIII Local Electoral District of Quintana Roo",
+        "lang:es": "XIII Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "XIV Local Electoral District of Quintana Roo",
-        "es": "XIV Distrito Electoral Local de Quintana Roo"
+        "lang:en": "XIV Local Electoral District of Quintana Roo",
+        "lang:es": "XIV Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Quintana Roo"
       },
       "name": {
-        "en": "XV Local Electoral District of Quintana Roo",
-        "es": "XV Distrito Electoral Local de Quintana Roo"
+        "lang:en": "XV Local Electoral District of Quintana Roo",
+        "lang:es": "XV Distrito Electoral Local de Quintana Roo"
       },
       "parent_id": "Q80245"
     },

--- a/legislative/Q5160894/Q53546090/popolo-m17n.json
+++ b/legislative/Q5160894/Q53546090/popolo-m17n.json
@@ -74,8 +74,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "I Local Electoral District of Sonora",
-        "es": "I Distrito Electoral Local de Sonora"
+        "lang:en": "I Local Electoral District of Sonora",
+        "lang:es": "I Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -98,8 +98,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "II Local Electoral District of Sonora",
-        "es": "II Distrito Electoral Local de Sonora"
+        "lang:en": "II Local Electoral District of Sonora",
+        "lang:es": "II Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -122,8 +122,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "III Local Electoral District of Sonora",
-        "es": "III Distrito Electoral Local de Sonora"
+        "lang:en": "III Local Electoral District of Sonora",
+        "lang:es": "III Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -146,8 +146,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "IV Local Electoral Distric of Sonora",
-        "es": "IV Distrito Electoral Local de Sonora"
+        "lang:en": "IV Local Electoral Distric of Sonora",
+        "lang:es": "IV Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -170,8 +170,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "V Local Electoral District of Sonora",
-        "es": "V Distrito Electoral Local de Sonora"
+        "lang:en": "V Local Electoral District of Sonora",
+        "lang:es": "V Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -218,8 +218,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "VI Local Electoral District of Sonora",
-        "es": "VI Distrito Electoral Local de Sonora"
+        "lang:en": "VI Local Electoral District of Sonora",
+        "lang:es": "VI Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -242,8 +242,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "VII Local Electoral District of Sonora",
-        "es": "VII Distrito Electoral Local de Sonora"
+        "lang:en": "VII Local Electoral District of Sonora",
+        "lang:es": "VII Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -266,8 +266,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "VIII Local Electoral District of Sonora",
-        "es": "VIII Distrito Electoral Local de Sonora"
+        "lang:en": "VIII Local Electoral District of Sonora",
+        "lang:es": "VIII Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -290,8 +290,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "IX Local Electoral District of Sonora",
-        "es": "IX Distrito Electoral Local de Sonora"
+        "lang:en": "IX Local Electoral District of Sonora",
+        "lang:es": "IX Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -314,8 +314,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "X Local Electoral District of Sonora",
-        "es": "X Distrito Electoral Local de Sonora"
+        "lang:en": "X Local Electoral District of Sonora",
+        "lang:es": "X Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -338,8 +338,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XI Local Electoral District of Sonora",
-        "es": "XI Distrito Electoral Local de Sonora"
+        "lang:en": "XI Local Electoral District of Sonora",
+        "lang:es": "XI Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -362,8 +362,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XII Local Electoral District of Sonora",
-        "es": "XII Distrito Electoral Local de Sonora"
+        "lang:en": "XII Local Electoral District of Sonora",
+        "lang:es": "XII Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -386,8 +386,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XIII Local Electoral District of Sonora",
-        "es": "XIII Distrito Electoral Local de Sonora"
+        "lang:en": "XIII Local Electoral District of Sonora",
+        "lang:es": "XIII Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -410,8 +410,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XIV Local Electoral District of Sonora",
-        "es": "XIV Distrito Electoral Local de Sonora"
+        "lang:en": "XIV Local Electoral District of Sonora",
+        "lang:es": "XIV Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -434,8 +434,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XV Local Electoral District of Sonora",
-        "es": "XV Distrito Electoral Local de Sonora"
+        "lang:en": "XV Local Electoral District of Sonora",
+        "lang:es": "XV Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -458,8 +458,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XVI Local Electoral District of Sonora",
-        "es": "XVI Distrito Electoral Local de Sonora"
+        "lang:en": "XVI Local Electoral District of Sonora",
+        "lang:es": "XVI Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -482,8 +482,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XVII Local Electoral District of Sonora",
-        "es": "XVII Distrito Electoral Local de Sonora"
+        "lang:en": "XVII Local Electoral District of Sonora",
+        "lang:es": "XVII Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -506,8 +506,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Sonora",
-        "es": "XVIII Distrito Electoral Local de Sonora"
+        "lang:en": "XVIII Local Electoral District of Sonora",
+        "lang:es": "XVIII Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -530,8 +530,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XIX Local Electoral District of Sonora",
-        "es": "XIX Distrito Electoral Local de Sonora"
+        "lang:en": "XIX Local Electoral District of Sonora",
+        "lang:es": "XIX Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -554,8 +554,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XX Local Electoral District of Sonora",
-        "es": "XX Distrito Electoral Local de Sonora"
+        "lang:en": "XX Local Electoral District of Sonora",
+        "lang:es": "XX Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },
@@ -578,8 +578,8 @@
         "lang:en": "local electoral district of Sonora"
       },
       "name": {
-        "en": "XXI Local Electoral District of Sonora",
-        "es": "XXI Distrito Electoral Local de Sonora"
+        "lang:en": "XXI Local Electoral District of Sonora",
+        "lang:es": "XXI Distrito Electoral Local de Sonora"
       },
       "parent_id": "Q46422"
     },

--- a/legislative/Q5160896/Q53546093/popolo-m17n.json
+++ b/legislative/Q5160896/Q53546093/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "I Local Electoral District of Tabasco",
-        "es": "I Distrito Electoral Local de Tabasco"
+        "lang:en": "I Local Electoral District of Tabasco",
+        "lang:es": "I Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "II Local Electoral District of Tabasco",
-        "es": "II Distrito Electoral Local de Tabasco"
+        "lang:en": "II Local Electoral District of Tabasco",
+        "lang:es": "II Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "III Local Electoral District of Tabasco",
-        "es": "III Distrito Electoral Local de Tabasco"
+        "lang:en": "III Local Electoral District of Tabasco",
+        "lang:es": "III Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "IV Local Electoral District of Tabasco",
-        "es": "IV Distrito Electoral Local de Tabasco"
+        "lang:en": "IV Local Electoral District of Tabasco",
+        "lang:es": "IV Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "V Local Electoral District of Tabasco",
-        "es": "V Distrito Electoral Local de Tabasco"
+        "lang:en": "V Local Electoral District of Tabasco",
+        "lang:es": "V Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "VI Local Electoral District of Tabasco",
-        "es": "VI Distrito Electoral Local de Tabasco"
+        "lang:en": "VI Local Electoral District of Tabasco",
+        "lang:es": "VI Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "VII Local Electoral District of Tabasco",
-        "es": "VII Distrito Electoral Local de Tabasco"
+        "lang:en": "VII Local Electoral District of Tabasco",
+        "lang:es": "VII Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "VIII Local Electoral District of Tabasco",
-        "es": "VIII Distrito Electoral Local de Tabasco"
+        "lang:en": "VIII Local Electoral District of Tabasco",
+        "lang:es": "VIII Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "IX Local Electoral District of Tabasco",
-        "es": "IX Distrito Electoral Local de Tabasco"
+        "lang:en": "IX Local Electoral District of Tabasco",
+        "lang:es": "IX Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "X Local Electoral District of Tabasco",
-        "es": "X Distrito Electoral Local de Tabasco"
+        "lang:en": "X Local Electoral District of Tabasco",
+        "lang:es": "X Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XI Local Electoral District of Tabasco",
-        "es": "XI Distrito Electoral Local de Tabasco"
+        "lang:en": "XI Local Electoral District of Tabasco",
+        "lang:es": "XI Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XII Local Electoral District of Tabasco",
-        "es": "XII Distrito Electoral Local de Tabasco"
+        "lang:en": "XII Local Electoral District of Tabasco",
+        "lang:es": "XII Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XIII Local Electoral District of Tabasco",
-        "es": "XIII Distrito Electoral Local de Tabasco"
+        "lang:en": "XIII Local Electoral District of Tabasco",
+        "lang:es": "XIII Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XIV Local Electoral District of Tabasco",
-        "es": "XIV Distrito Electoral Local de Tabasco"
+        "lang:en": "XIV Local Electoral District of Tabasco",
+        "lang:es": "XIV Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XV Local Electoral District of Tabasco",
-        "es": "XV Distrito Electoral Local de Tabasco"
+        "lang:en": "XV Local Electoral District of Tabasco",
+        "lang:es": "XV Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XVI Local Electoral District of Tabasco",
-        "es": "XVI Distrito Electoral Local de Tabasco"
+        "lang:en": "XVI Local Electoral District of Tabasco",
+        "lang:es": "XVI Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XVII Local Electoral District of Tabasco",
-        "es": "XVII Distrito Electoral Local de Tabasco"
+        "lang:en": "XVII Local Electoral District of Tabasco",
+        "lang:es": "XVII Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Tabasco",
-        "es": "XVIII Distrito Electoral Local de Tabasco"
+        "lang:en": "XVIII Local Electoral District of Tabasco",
+        "lang:es": "XVIII Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XIX Local Electoral District of Tabasco",
-        "es": "XIX Distrito Electoral Local de Tabasco"
+        "lang:en": "XIX Local Electoral District of Tabasco",
+        "lang:es": "XIX Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XX Local Electoral District of Tabasco",
-        "es": "XX Distrito Electoral Local de Tabasco"
+        "lang:en": "XX Local Electoral District of Tabasco",
+        "lang:es": "XX Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Tabasco"
       },
       "name": {
-        "en": "XXI Local Electoral District of Tabasco",
-        "es": "XXI Distrito Electoral Local de Tabasco"
+        "lang:en": "XXI Local Electoral District of Tabasco",
+        "lang:es": "XXI Distrito Electoral Local de Tabasco"
       },
       "parent_id": "Q80914"
     },

--- a/legislative/Q5160897/Q53546094/popolo-m17n.json
+++ b/legislative/Q5160897/Q53546094/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "I Local Electoral District of Tamaulipas",
-        "es": "I Distrito Electoral Local de Tamaulipas"
+        "lang:en": "I Local Electoral District of Tamaulipas",
+        "lang:es": "I Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "II Local Electoral District of Tamaulipas",
-        "es": "II Distrito Electoral Local de Tamaulipas"
+        "lang:en": "II Local Electoral District of Tamaulipas",
+        "lang:es": "II Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "III Local Electoral District of Tamaulipas",
-        "es": "III Distrito Electoral Local de Tamaulipas"
+        "lang:en": "III Local Electoral District of Tamaulipas",
+        "lang:es": "III Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "IV Local Electoral District of Tamaulipas",
-        "es": "IV Distrito Electoral Local de Tamaulipas"
+        "lang:en": "IV Local Electoral District of Tamaulipas",
+        "lang:es": "IV Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "V Local Electoral District of Tamaulipas",
-        "es": "V Distrito Electoral Local de Tamaulipas"
+        "lang:en": "V Local Electoral District of Tamaulipas",
+        "lang:es": "V Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "VI Local Electoral District of Tamaulipas",
-        "es": "VI Distrito Electoral Local de Tamaulipas"
+        "lang:en": "VI Local Electoral District of Tamaulipas",
+        "lang:es": "VI Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "VII Local Electoral District of Tamaulipas",
-        "es": "VII Distrito Electoral Local de Tamaulipas"
+        "lang:en": "VII Local Electoral District of Tamaulipas",
+        "lang:es": "VII Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "VIII Local Electoral District of Tamaulipas",
-        "es": "VIII Distrito Electoral Local de Tamaulipas"
+        "lang:en": "VIII Local Electoral District of Tamaulipas",
+        "lang:es": "VIII Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "IX Local Electoral District of Tamaulipas",
-        "es": "IX Distrito Electoral Local de Tamaulipas"
+        "lang:en": "IX Local Electoral District of Tamaulipas",
+        "lang:es": "IX Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "X Local Electoral District of Tamaulipas",
-        "es": "X Distrito Electoral Local de Tamaulipas"
+        "lang:en": "X Local Electoral District of Tamaulipas",
+        "lang:es": "X Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XI Local Electoral District of Tamaulipas",
-        "es": "XI Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XI Local Electoral District of Tamaulipas",
+        "lang:es": "XI Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XII Local Electoral District of Tamaulipas",
-        "es": "XII Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XII Local Electoral District of Tamaulipas",
+        "lang:es": "XII Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XIII Local Electoral District of Tamaulipas",
-        "es": "XIII Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XIII Local Electoral District of Tamaulipas",
+        "lang:es": "XIII Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XIV Local Electoral District of Tamaulipas",
-        "es": "XIV Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XIV Local Electoral District of Tamaulipas",
+        "lang:es": "XIV Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XV Local Electoral District of Tamaulipas",
-        "es": "XV Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XV Local Electoral District of Tamaulipas",
+        "lang:es": "XV Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XVI Local Electoral District of Tamaulipas",
-        "es": "XVI Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XVI Local Electoral District of Tamaulipas",
+        "lang:es": "XVI Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XVII Local Electoral District of Tamaulipas",
-        "es": "XVII Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XVII Local Electoral District of Tamaulipas",
+        "lang:es": "XVII Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Tamaulipas",
-        "es": "XVIII Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XVIII Local Electoral District of Tamaulipas",
+        "lang:es": "XVIII Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XIX Local Electoral District of Tamaulipas",
-        "es": "XIX Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XIX Local Electoral District of Tamaulipas",
+        "lang:es": "XIX Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XX Local Electoral District of Tamaulipas",
-        "es": "XX Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XX Local Electoral District of Tamaulipas",
+        "lang:es": "XX Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XXI Local Electoral District of Tamaulipas",
-        "es": "XXI Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XXI Local Electoral District of Tamaulipas",
+        "lang:es": "XXI Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Tamaulipas"
       },
       "name": {
-        "en": "XXII Local Electoral District of Tamaulipas",
-        "es": "XXII Distrito Electoral Local de Tamaulipas"
+        "lang:en": "XXII Local Electoral District of Tamaulipas",
+        "lang:es": "XXII Distrito Electoral Local de Tamaulipas"
       },
       "parent_id": "Q80007"
     },

--- a/legislative/Q5160905/Q53546116/popolo-m17n.json
+++ b/legislative/Q5160905/Q53546116/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "I Local Electoral District of Zacatecas",
-        "es": "I Distrito Electoral Local de Zacatecas"
+        "lang:en": "I Local Electoral District of Zacatecas",
+        "lang:es": "I Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "II Local Electoral District of Zacatecas",
-        "es": "II Distrito Electoral Local de Zacatecas"
+        "lang:en": "II Local Electoral District of Zacatecas",
+        "lang:es": "II Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "III Local Electoral District of Zacatecas",
-        "es": "III Distrito Electoral Local de Zacatecas"
+        "lang:en": "III Local Electoral District of Zacatecas",
+        "lang:es": "III Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "IV Local Electoral District of Zacatecas",
-        "es": "IV Distrito Electoral Local de Zacatecas"
+        "lang:en": "IV Local Electoral District of Zacatecas",
+        "lang:es": "IV Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "V Local Electoral District of Zacatecas",
-        "es": "V Distrito Electoral Local de Zacatecas"
+        "lang:en": "V Local Electoral District of Zacatecas",
+        "lang:es": "V Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "VI Local Electoral District of Zacatecas",
-        "es": "VI Distrito Electoral Local de Zacatecas"
+        "lang:en": "VI Local Electoral District of Zacatecas",
+        "lang:es": "VI Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "VII Local Electoral District of Zacatecas",
-        "es": "VII Distrito Electoral Local de Zacatecas"
+        "lang:en": "VII Local Electoral District of Zacatecas",
+        "lang:es": "VII Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "VIII Local Electoral District of Zacatecas",
-        "es": "VIII Distrito Electoral Local de Zacatecas"
+        "lang:en": "VIII Local Electoral District of Zacatecas",
+        "lang:es": "VIII Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "IX Local Electoral District of Zacatecas",
-        "es": "IX Distrito Electoral Local de Zacatecas"
+        "lang:en": "IX Local Electoral District of Zacatecas",
+        "lang:es": "IX Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "X Local Electoral District of Zacatecas",
-        "es": "X Distrito Electoral Local de Zacatecas"
+        "lang:en": "X Local Electoral District of Zacatecas",
+        "lang:es": "X Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "XI Local Electoral District of Zacatecas",
-        "es": "XI Distrito Electoral Local de Zacatecas"
+        "lang:en": "XI Local Electoral District of Zacatecas",
+        "lang:es": "XI Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "XII Local Electoral District of Zacatecas",
-        "es": "XII Distrito Electoral Local de Zacatecas"
+        "lang:en": "XII Local Electoral District of Zacatecas",
+        "lang:es": "XII Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "XIII Local Electoral District of Zacatecas",
-        "es": "XIII Distrito Electoral Local de Zacatecas"
+        "lang:en": "XIII Local Electoral District of Zacatecas",
+        "lang:es": "XIII Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "XIV Local Electoral District of Zacatecas",
-        "es": "XIV Distrito Electoral Local de Zacatecas"
+        "lang:en": "XIV Local Electoral District of Zacatecas",
+        "lang:es": "XIV Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "XV Local Electoral District of Zacatecas",
-        "es": "XV Distrito Electoral Local de Zacatecas"
+        "lang:en": "XV Local Electoral District of Zacatecas",
+        "lang:es": "XV Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "XVI Local Electoral District of Zacatecas",
-        "es": "XVI Distrito Electoral Local de Zacatecas"
+        "lang:en": "XVI Local Electoral District of Zacatecas",
+        "lang:es": "XVI Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "XVII Local Electoral District of Zacatecas",
-        "es": "XVII Distrito Electoral Local de Zacatecas"
+        "lang:en": "XVII Local Electoral District of Zacatecas",
+        "lang:es": "XVII Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Zacatecas"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Zacatecas",
-        "es": "XVIII Distrito Electoral Local de Zacatecas"
+        "lang:en": "XVIII Local Electoral District of Zacatecas",
+        "lang:es": "XVIII Distrito Electoral Local de Zacatecas"
       },
       "parent_id": "Q80269"
     },

--- a/legislative/Q5160907/Q53546115/popolo-m17n.json
+++ b/legislative/Q5160907/Q53546115/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "I Local Electoral District of Yucatan",
-        "es": "I Distrito Electoral Local de Yucatan"
+        "lang:en": "I Local Electoral District of Yucatan",
+        "lang:es": "I Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "II Local Electoral District of Yucatan",
-        "es": "II Distrito Electoral Local de Yucatan"
+        "lang:en": "II Local Electoral District of Yucatan",
+        "lang:es": "II Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "III Local Electoral District of Yucatan",
-        "es": "III Distrito Electoral Local de Yucatan"
+        "lang:en": "III Local Electoral District of Yucatan",
+        "lang:es": "III Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "IV Local Electoral District of Yucatan",
-        "es": "IV Distrito Electoral Local de Yucatan"
+        "lang:en": "IV Local Electoral District of Yucatan",
+        "lang:es": "IV Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "V Local Electoral District of Yucatan",
-        "es": "V Distrito Electoral Local de Yucatan"
+        "lang:en": "V Local Electoral District of Yucatan",
+        "lang:es": "V Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "VI Local Electoral District of Yucatan",
-        "es": "VI Distrito Electoral Local de Yucatan"
+        "lang:en": "VI Local Electoral District of Yucatan",
+        "lang:es": "VI Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "VII Local Electoral District of Yucatan",
-        "es": "VII Distrito Electoral Local de Yucatan"
+        "lang:en": "VII Local Electoral District of Yucatan",
+        "lang:es": "VII Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "VIII Local Electoral District of Yucatan",
-        "es": "VIII Distrito Electoral Local de Yucatan"
+        "lang:en": "VIII Local Electoral District of Yucatan",
+        "lang:es": "VIII Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "IX Local Electoral District of Yucatan",
-        "es": "IX Distrito Electoral Local de Yucatan"
+        "lang:en": "IX Local Electoral District of Yucatan",
+        "lang:es": "IX Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "X Local Electoral District of Yucatan",
-        "es": "X Distrito Electoral Local de Yucatan"
+        "lang:en": "X Local Electoral District of Yucatan",
+        "lang:es": "X Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "XI Local Electoral District of Yucatan",
-        "es": "XI Distrito Electoral Local de Yucatan"
+        "lang:en": "XI Local Electoral District of Yucatan",
+        "lang:es": "XI Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "XII Local Electoral District of Yucatan",
-        "es": "XII Distrito Electoral Local de Yucatan"
+        "lang:en": "XII Local Electoral District of Yucatan",
+        "lang:es": "XII Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "XIII Local Electoral District of Yucatan",
-        "es": "XIII Distrito Electoral Local de Yucatan"
+        "lang:en": "XIII Local Electoral District of Yucatan",
+        "lang:es": "XIII Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "XIV Local Electoral District of Yucatan",
-        "es": "XIV Distrito Electoral Local de Yucatan"
+        "lang:en": "XIV Local Electoral District of Yucatan",
+        "lang:es": "XIV Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Yucatan"
       },
       "name": {
-        "en": "XV Local Electoral District of Yucatan",
-        "es": "XV Distrito Electoral Local de Yucatan"
+        "lang:en": "XV Local Electoral District of Yucatan",
+        "lang:es": "XV Distrito Electoral Local de Yucatan"
       },
       "parent_id": "Q60176"
     },

--- a/legislative/Q5160913/Q53546050/popolo-m17n.json
+++ b/legislative/Q5160913/Q53546050/popolo-m17n.json
@@ -74,8 +74,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "I Local Electoral District of México",
-        "es": "I Distrito Electoral Local de México"
+        "lang:en": "I Local Electoral District of México",
+        "lang:es": "I Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -98,8 +98,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "II Local Electoral District of México",
-        "es": "II Distrito Electoral Local de México"
+        "lang:en": "II Local Electoral District of México",
+        "lang:es": "II Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -122,8 +122,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "III Local Electoral District of México",
-        "es": "III Distrito Electoral Local de México"
+        "lang:en": "III Local Electoral District of México",
+        "lang:es": "III Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -146,8 +146,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "IV Local Electoral District of México",
-        "es": "IV Distrito Electoral Local de México"
+        "lang:en": "IV Local Electoral District of México",
+        "lang:es": "IV Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -170,8 +170,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "V Local Electoral District of México",
-        "es": "V Distrito Electoral Local de México"
+        "lang:en": "V Local Electoral District of México",
+        "lang:es": "V Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -194,8 +194,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "VI Local Electoral District of México",
-        "es": "VI Distrito Electoral Local de México"
+        "lang:en": "VI Local Electoral District of México",
+        "lang:es": "VI Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -218,8 +218,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "VII Local Electoral District of México",
-        "es": "VII Distrito Electoral Local de México"
+        "lang:en": "VII Local Electoral District of México",
+        "lang:es": "VII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -242,8 +242,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "VIII Local Electoral District of México",
-        "es": "VIII Distrito Electoral Local de México"
+        "lang:en": "VIII Local Electoral District of México",
+        "lang:es": "VIII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -266,8 +266,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "IX Local Electoral District of México",
-        "es": "IX Distrito Electoral Local de México"
+        "lang:en": "IX Local Electoral District of México",
+        "lang:es": "IX Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -290,8 +290,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "X Local Electoral District of México",
-        "es": "X Distrito Electoral Local de México"
+        "lang:en": "X Local Electoral District of México",
+        "lang:es": "X Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -314,8 +314,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XI Local Electoral District of México",
-        "es": "XI Distrito Electoral Local de México"
+        "lang:en": "XI Local Electoral District of México",
+        "lang:es": "XI Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -338,8 +338,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XII Local Electoral District of México",
-        "es": "XII Distrito Electoral Local de México"
+        "lang:en": "XII Local Electoral District of México",
+        "lang:es": "XII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -362,8 +362,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XIII Local Electoral District of México",
-        "es": "XIII Distrito Electoral Local de México"
+        "lang:en": "XIII Local Electoral District of México",
+        "lang:es": "XIII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -386,8 +386,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XIV Local Electoral District of México",
-        "es": "XIV Distrito Electoral Local de México"
+        "lang:en": "XIV Local Electoral District of México",
+        "lang:es": "XIV Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -410,8 +410,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XV Local Electoral District of México",
-        "es": "XV Distrito Electoral Local de México"
+        "lang:en": "XV Local Electoral District of México",
+        "lang:es": "XV Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -434,8 +434,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XVI Local Electoral District of México",
-        "es": "XVI Distrito Electoral Local de México"
+        "lang:en": "XVI Local Electoral District of México",
+        "lang:es": "XVI Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -458,8 +458,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XVII Local Electoral District of México",
-        "es": "XVII Distrito Electoral Local de México"
+        "lang:en": "XVII Local Electoral District of México",
+        "lang:es": "XVII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -482,8 +482,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XVIII Local Electoral District of México",
-        "es": "XVIII Distrito Electoral Local de México"
+        "lang:en": "XVIII Local Electoral District of México",
+        "lang:es": "XVIII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -506,8 +506,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XIX Local Electoral District of México",
-        "es": "XIX Distrito Electoral Local de México"
+        "lang:en": "XIX Local Electoral District of México",
+        "lang:es": "XIX Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -530,8 +530,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XX Local Electoral District of México",
-        "es": "XX Distrito Electoral Local de México"
+        "lang:en": "XX Local Electoral District of México",
+        "lang:es": "XX Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -554,8 +554,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXI Local Electoral District of México",
-        "es": "XXI Distrito Electoral Local de México"
+        "lang:en": "XXI Local Electoral District of México",
+        "lang:es": "XXI Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -578,8 +578,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXII Local Electoral District of México",
-        "es": "XXII Distrito Electoral Local de México"
+        "lang:en": "XXII Local Electoral District of México",
+        "lang:es": "XXII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -602,8 +602,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXIII Local Electoral District of México",
-        "es": "XXIII Distrito Electoral Local de México"
+        "lang:en": "XXIII Local Electoral District of México",
+        "lang:es": "XXIII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -626,8 +626,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXIV Local Electoral District of México",
-        "es": "XXIV Distrito Electoral Local de México"
+        "lang:en": "XXIV Local Electoral District of México",
+        "lang:es": "XXIV Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -650,8 +650,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXV Local Electoral District of México",
-        "es": "XXV Distrito Electoral Local de México"
+        "lang:en": "XXV Local Electoral District of México",
+        "lang:es": "XXV Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -674,8 +674,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXVI Local Electoral District of México",
-        "es": "XXVI Distrito Electoral Local de México"
+        "lang:en": "XXVI Local Electoral District of México",
+        "lang:es": "XXVI Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -698,8 +698,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXVII Local Electoral District of México",
-        "es": "XXVII Distrito Electoral Local de México"
+        "lang:en": "XXVII Local Electoral District of México",
+        "lang:es": "XXVII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -722,8 +722,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXVIII Local Electoral District of México",
-        "es": "XXVIII Distrito Electoral Local de México"
+        "lang:en": "XXVIII Local Electoral District of México",
+        "lang:es": "XXVIII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -746,8 +746,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXIX Local Electoral District of México",
-        "es": "XXIX Distrito Electoral Local de México"
+        "lang:en": "XXIX Local Electoral District of México",
+        "lang:es": "XXIX Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -770,8 +770,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXX Local Electoral District of México",
-        "es": "XXX Distrito Electoral Local de México"
+        "lang:en": "XXX Local Electoral District of México",
+        "lang:es": "XXX Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -794,8 +794,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXXI Local Electoral District of México",
-        "es": "XXXI Distrito Electoral Local de México"
+        "lang:en": "XXXI Local Electoral District of México",
+        "lang:es": "XXXI Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -818,8 +818,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXXII Local Electoral District of México",
-        "es": "XXXII Distrito Electoral Local de México"
+        "lang:en": "XXXII Local Electoral District of México",
+        "lang:es": "XXXII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -842,8 +842,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXXIII Local Electoral District of México",
-        "es": "XXXIII Distrito Electoral Local de México"
+        "lang:en": "XXXIII Local Electoral District of México",
+        "lang:es": "XXXIII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -866,8 +866,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXXIV Local Electoral District of México",
-        "es": "XXXIV Distrito Electoral Local de México"
+        "lang:en": "XXXIV Local Electoral District of México",
+        "lang:es": "XXXIV Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -890,8 +890,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXXV Local Electoral District of México",
-        "es": "XXXV Distrito Electoral Local de México"
+        "lang:en": "XXXV Local Electoral District of México",
+        "lang:es": "XXXV Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -914,8 +914,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXXVI Local Electoral District of México",
-        "es": "XXXVI Distrito Electoral Local de México"
+        "lang:en": "XXXVI Local Electoral District of México",
+        "lang:es": "XXXVI Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -938,8 +938,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXXVII Local Electoral District of México",
-        "es": "XXXVII Distrito Electoral Local de México"
+        "lang:en": "XXXVII Local Electoral District of México",
+        "lang:es": "XXXVII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -962,8 +962,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXXVIII Local Electoral District of México",
-        "es": "XXXVIII Distrito Electoral Local de México"
+        "lang:en": "XXXVIII Local Electoral District of México",
+        "lang:es": "XXXVIII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -986,8 +986,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XXXIX Local Electoral District of México",
-        "es": "XXXIX Distrito Electoral Local de México"
+        "lang:en": "XXXIX Local Electoral District of México",
+        "lang:es": "XXXIX Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -1010,8 +1010,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XL Local Electoral District of México",
-        "es": "XL Distrito Electoral Local de México"
+        "lang:en": "XL Local Electoral District of México",
+        "lang:es": "XL Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -1034,8 +1034,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XLI Local Electoral District of México",
-        "es": "XLI Distrito Electoral Local de México"
+        "lang:en": "XLI Local Electoral District of México",
+        "lang:es": "XLI Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -1058,8 +1058,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XLII Local Electoral District of México",
-        "es": "XLII Distrito Electoral Local de México"
+        "lang:en": "XLII Local Electoral District of México",
+        "lang:es": "XLII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -1082,8 +1082,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XLIII Local Electoral District of México",
-        "es": "XLIII Distrito Electoral Local de México"
+        "lang:en": "XLIII Local Electoral District of México",
+        "lang:es": "XLIII Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -1106,8 +1106,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XLIV Local Electoral District of México",
-        "es": "XLIV Distrito Electoral Local de México"
+        "lang:en": "XLIV Local Electoral District of México",
+        "lang:es": "XLIV Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },
@@ -1130,8 +1130,8 @@
         "lang:en": "local electoral district of Mexico"
       },
       "name": {
-        "en": "XLV Local Electoral District of México",
-        "es": "XLV Distrito Electoral Local de México"
+        "lang:en": "XLV Local Electoral District of México",
+        "lang:es": "XLV Distrito Electoral Local de México"
       },
       "parent_id": "Q82112"
     },

--- a/legislative/Q53542909/Q53546029/popolo-m17n.json
+++ b/legislative/Q53542909/Q53546029/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "I Local Electoral District of Aguascalientes",
-        "es": "I Distrito Electoral Local de Aguascalientes"
+        "lang:en": "I Local Electoral District of Aguascalientes",
+        "lang:es": "I Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "II Local Electoral District of Aguascalientes",
-        "es": "II Distrito Electoral Local de Aguascalientes"
+        "lang:en": "II Local Electoral District of Aguascalientes",
+        "lang:es": "II Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "III Local Electoral District of Aguascalientes",
-        "es": "III Distrito Electoral Local de Aguascalientes"
+        "lang:en": "III Local Electoral District of Aguascalientes",
+        "lang:es": "III Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "V Local Electoral District of Aguascalientes",
-        "es": "V Distrito Electoral Local de Aguascalientes"
+        "lang:en": "V Local Electoral District of Aguascalientes",
+        "lang:es": "V Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "VI Local Electoral District of Aguascalientes",
-        "es": "VI Distrito Electoral Local de Aguascalientes"
+        "lang:en": "VI Local Electoral District of Aguascalientes",
+        "lang:es": "VI Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "VII Local Electoral District of Aguascalientes",
-        "es": "VII Distrito Electoral Local de Aguascalientes"
+        "lang:en": "VII Local Electoral District of Aguascalientes",
+        "lang:es": "VII Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "VIII Local Electoral District of Aguascalientes",
-        "es": "VIII Distrito Electoral Local de Aguascalientes"
+        "lang:en": "VIII Local Electoral District of Aguascalientes",
+        "lang:es": "VIII Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "IX Local Electoral District of Aguascalientes",
-        "es": "IX Distrito Electoral Local de Aguascalientes"
+        "lang:en": "IX Local Electoral District of Aguascalientes",
+        "lang:es": "IX Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "X Local Electoral District of Aguascalientes",
-        "es": "X Distrito Electoral Local de Aguascalientes"
+        "lang:en": "X Local Electoral District of Aguascalientes",
+        "lang:es": "X Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "XI Local Electoral District of Aguascalientes",
-        "es": "XI Distrito Electoral Local de Aguascalientes"
+        "lang:en": "XI Local Electoral District of Aguascalientes",
+        "lang:es": "XI Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "XII Local Electoral District of Aguascalientes",
-        "es": "XII Distrito Electoral Local de Aguascalientes"
+        "lang:en": "XII Local Electoral District of Aguascalientes",
+        "lang:es": "XII Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "XIII Local Electoral District of Aguascalientes",
-        "es": "XIII Distrito Electoral Local de Aguascalientes"
+        "lang:en": "XIII Local Electoral District of Aguascalientes",
+        "lang:es": "XIII Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "XIV Local Electoral District of Aguascalientes",
-        "es": "XIV Distrito Electoral Local de Aguascalientes"
+        "lang:en": "XIV Local Electoral District of Aguascalientes",
+        "lang:es": "XIV Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "XV Local Electoral District of Aguascalientes",
-        "es": "XV Distrito Electoral Local de Aguascalientes"
+        "lang:en": "XV Local Electoral District of Aguascalientes",
+        "lang:es": "XV Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "XVI Local Electoral District of Aguascalientes",
-        "es": "XVI Distrito Electoral Local de Aguascalientes"
+        "lang:en": "XVI Local Electoral District of Aguascalientes",
+        "lang:es": "XVI Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "XVII Local Electoral District of Aguascalientes",
-        "es": "XVII Distrito Electoral Local de Aguascalientes"
+        "lang:en": "XVII Local Electoral District of Aguascalientes",
+        "lang:es": "XVII Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Aguascalientes",
-        "es": "XVIII Distrito Electoral Local de Aguascalientes"
+        "lang:en": "XVIII Local Electoral District of Aguascalientes",
+        "lang:es": "XVIII Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Aguascalientes"
       },
       "name": {
-        "en": "IV Local Electoral District of Aguascalientes",
-        "es": "IV Distrito Electoral Local de Aguascalientes"
+        "lang:en": "IV Local Electoral District of Aguascalientes",
+        "lang:es": "IV Distrito Electoral Local de Aguascalientes"
       },
       "parent_id": "Q79952"
     },

--- a/legislative/Q53542913/Q53546031/popolo-m17n.json
+++ b/legislative/Q53542913/Q53546031/popolo-m17n.json
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "I Local Electoral District of Baja California Sur",
-        "es": "I Distrito Electoral Local de Baja California Sur"
+        "lang:en": "I Local Electoral District of Baja California Sur",
+        "lang:es": "I Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "II Local Electoral District of Baja California Sur",
-        "es": "II Distrito Electoral Local de Baja California Sur"
+        "lang:en": "II Local Electoral District of Baja California Sur",
+        "lang:es": "II Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "III Local Electoral District of Baja California Sur",
-        "es": "III Distrito Electoral Local de Baja California Sur"
+        "lang:en": "III Local Electoral District of Baja California Sur",
+        "lang:es": "III Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "IV Local Electoral District of Baja California Sur",
-        "es": "IV Distrito Electoral Local de Baja California Sur"
+        "lang:en": "IV Local Electoral District of Baja California Sur",
+        "lang:es": "IV Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "V Local Electoral District of Baja California Sur",
-        "es": "V Distrito Electoral Local de Baja California Sur"
+        "lang:en": "V Local Electoral District of Baja California Sur",
+        "lang:es": "V Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "VI Local Electoral District of Baja California Sur",
-        "es": "VI Distrito Electoral Local de Baja California Sur"
+        "lang:en": "VI Local Electoral District of Baja California Sur",
+        "lang:es": "VI Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "VII Local Electoral District of Baja California Sur",
-        "es": "VII Distrito Electoral Local de Baja California Sur"
+        "lang:en": "VII Local Electoral District of Baja California Sur",
+        "lang:es": "VII Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "VIII Local Electoral District of Baja California Sur",
-        "es": "VIII Distrito Electoral Local de Baja California Sur"
+        "lang:en": "VIII Local Electoral District of Baja California Sur",
+        "lang:es": "VIII Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "IX Local Electoral District of Baja California Sur",
-        "es": "IX Distrito Electoral Local de Baja California Sur"
+        "lang:en": "IX Local Electoral District of Baja California Sur",
+        "lang:es": "IX Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "X Local Electoral District of Baja California Sur",
-        "es": "X Distrito Electoral Local de Baja California Sur"
+        "lang:en": "X Local Electoral District of Baja California Sur",
+        "lang:es": "X Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "XI Local Electoral District of Baja California Sur",
-        "es": "XI Distrito Electoral Local de Baja California Sur"
+        "lang:en": "XI Local Electoral District of Baja California Sur",
+        "lang:es": "XI Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "XII Local Electoral District of Baja California Sur",
-        "es": "XII Distrito Electoral Local de Baja California Sur"
+        "lang:en": "XII Local Electoral District of Baja California Sur",
+        "lang:es": "XII Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "XIII Local Electoral District of Baja California Sur",
-        "es": "XIII Distrito Electoral Local de Baja California Sur"
+        "lang:en": "XIII Local Electoral District of Baja California Sur",
+        "lang:es": "XIII Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "XIV Local Electoral District of Baja California Sur",
-        "es": "XIV Distrito Electoral Local de Baja California Sur"
+        "lang:en": "XIV Local Electoral District of Baja California Sur",
+        "lang:es": "XIV Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "XV Local Electoral District of Baja California Sur",
-        "es": "XV Distrito Electoral Local de Baja California Sur"
+        "lang:en": "XV Local Electoral District of Baja California Sur",
+        "lang:es": "XV Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Baja California Sur"
       },
       "name": {
-        "en": "XVI Local Electoral District of Baja California Sur",
-        "es": "XVI Distrito Electoral Local de Baja California Sur"
+        "lang:en": "XVI Local Electoral District of Baja California Sur",
+        "lang:es": "XVI Distrito Electoral Local de Baja California Sur"
       },
       "parent_id": "Q46508"
     },

--- a/legislative/Q53542914/Q53546065/popolo-m17n.json
+++ b/legislative/Q53542914/Q53546065/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "I Local Electoral District of Nayarit",
-        "es": "I Distrito Electoral Local de Nayarit"
+        "lang:en": "I Local Electoral District of Nayarit",
+        "lang:es": "I Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "II Local Electoral District of Nayarit",
-        "es": "II Distrito Electoral Local de Nayarit"
+        "lang:en": "II Local Electoral District of Nayarit",
+        "lang:es": "II Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "III Local Electoral District of Nayarit",
-        "es": "III Distrito Electoral Local de Nayarit"
+        "lang:en": "III Local Electoral District of Nayarit",
+        "lang:es": "III Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "IV Local Electoral District of Nayarit",
-        "es": "IV Distrito Electoral Local de Nayarit"
+        "lang:en": "IV Local Electoral District of Nayarit",
+        "lang:es": "IV Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "V Local Electoral District of Nayarit",
-        "es": "V Distrito Electoral Local de Nayarit"
+        "lang:en": "V Local Electoral District of Nayarit",
+        "lang:es": "V Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "VI Local Electoral District of Nayarit",
-        "es": "VI Distrito Electoral Local de Nayarit"
+        "lang:en": "VI Local Electoral District of Nayarit",
+        "lang:es": "VI Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "VII Local Electoral District of Nayarit",
-        "es": "VII Distrito Electoral Local de Nayarit"
+        "lang:en": "VII Local Electoral District of Nayarit",
+        "lang:es": "VII Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "VIII Local Electoral District of Nayarit",
-        "es": "VIII Distrito Electoral Local de Nayarit"
+        "lang:en": "VIII Local Electoral District of Nayarit",
+        "lang:es": "VIII Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "IX Local Electoral District of Nayarit",
-        "es": "IX Distrito Electoral Local de Nayarit"
+        "lang:en": "IX Local Electoral District of Nayarit",
+        "lang:es": "IX Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "X Local Electoral District of Nayarit",
-        "es": "X Distrito Electoral Local de Nayarit"
+        "lang:en": "X Local Electoral District of Nayarit",
+        "lang:es": "X Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "XI Local Electoral District of Nayarit",
-        "es": "XI Distrito Electoral Local de Nayarit"
+        "lang:en": "XI Local Electoral District of Nayarit",
+        "lang:es": "XI Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "XII Local Electoral District of Nayarit",
-        "es": "XII Distrito Electoral Local de Nayarit"
+        "lang:en": "XII Local Electoral District of Nayarit",
+        "lang:es": "XII Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "XIII Local Electoral District of Nayarit",
-        "es": "XIII Distrito Electoral Local de Nayarit"
+        "lang:en": "XIII Local Electoral District of Nayarit",
+        "lang:es": "XIII Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "XIV Local Electoral District of Nayarit",
-        "es": "XIV Distrito Electoral Local de Nayarit"
+        "lang:en": "XIV Local Electoral District of Nayarit",
+        "lang:es": "XIV Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "XV Local Electoral District of Nayarit",
-        "es": "XV Distrito Electoral Local de Nayarit"
+        "lang:en": "XV Local Electoral District of Nayarit",
+        "lang:es": "XV Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "XVI Local Electoral District of Nayarit",
-        "es": "XVI Distrito Electoral Local de Nayarit"
+        "lang:en": "XVI Local Electoral District of Nayarit",
+        "lang:es": "XVI Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "XVII Local Electoral District of Nayarit",
-        "es": "XVII Distrito Electoral Local de Nayarit"
+        "lang:en": "XVII Local Electoral District of Nayarit",
+        "lang:es": "XVII Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Nayarit"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Nayarit",
-        "es": "XVIII Distrito Electoral Local de Nayarit"
+        "lang:en": "XVIII Local Electoral District of Nayarit",
+        "lang:es": "XVIII Distrito Electoral Local de Nayarit"
       },
       "parent_id": "Q79920"
     },

--- a/legislative/Q53542917/Q53546083/popolo-m17n.json
+++ b/legislative/Q53542917/Q53546083/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "I Local Electoral District of Queretaro",
-        "es": "I Distrito Electoral Local de Queretaro"
+        "lang:en": "I Local Electoral District of Queretaro",
+        "lang:es": "I Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "II Local Electoral District of Queretaro",
-        "es": "II Distrito Electoral Local de Queretaro"
+        "lang:en": "II Local Electoral District of Queretaro",
+        "lang:es": "II Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "III Local Electoral District of Queretaro",
-        "es": "III Distrito Electoral Local de Queretaro"
+        "lang:en": "III Local Electoral District of Queretaro",
+        "lang:es": "III Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "IV Local Electoral District of Queretaro",
-        "es": "IV Distrito Electoral Local de Queretaro"
+        "lang:en": "IV Local Electoral District of Queretaro",
+        "lang:es": "IV Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "V Local Electoral District of Queretaro",
-        "es": "V Distrito Electoral Local de Queretaro"
+        "lang:en": "V Local Electoral District of Queretaro",
+        "lang:es": "V Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "VI Local Electoral District of Queretaro",
-        "es": "VI Distrito Electoral Local de Queretaro"
+        "lang:en": "VI Local Electoral District of Queretaro",
+        "lang:es": "VI Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "VII Local Electoral District of Queretaro",
-        "es": "VII Distrito Electoral Local de Queretaro"
+        "lang:en": "VII Local Electoral District of Queretaro",
+        "lang:es": "VII Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "VIII Local Electoral District of Queretaro",
-        "es": "VIII Distrito Electoral Local de Queretaro"
+        "lang:en": "VIII Local Electoral District of Queretaro",
+        "lang:es": "VIII Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "IX Local Electoral District of Queretaro",
-        "es": "IX Distrito Electoral Local de Queretaro"
+        "lang:en": "IX Local Electoral District of Queretaro",
+        "lang:es": "IX Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "X Local Electoral District of Queretaro",
-        "es": "X Distrito Electoral Local de Queretaro"
+        "lang:en": "X Local Electoral District of Queretaro",
+        "lang:es": "X Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "XI Local Electoral District of Queretaro",
-        "es": "XI Distrito Electoral Local de Queretaro"
+        "lang:en": "XI Local Electoral District of Queretaro",
+        "lang:es": "XI Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "XII Local Electoral District of Queretaro",
-        "es": "XII Distrito Electoral Local de Queretaro"
+        "lang:en": "XII Local Electoral District of Queretaro",
+        "lang:es": "XII Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "XIII Local Electoral District of Queretaro",
-        "es": "XIII Distrito Electoral Local de Queretaro"
+        "lang:en": "XIII Local Electoral District of Queretaro",
+        "lang:es": "XIII Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "XIV Local Electoral District of Queretaro",
-        "es": "XIV Distrito Electoral Local de Queretaro"
+        "lang:en": "XIV Local Electoral District of Queretaro",
+        "lang:es": "XIV Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Queretaro"
       },
       "name": {
-        "en": "XV Local Electoral District of Queretaro",
-        "es": "XV Distrito Electoral Local de Queretaro"
+        "lang:en": "XV Local Electoral District of Queretaro",
+        "lang:es": "XV Distrito Electoral Local de Queretaro"
       },
       "parent_id": "Q79754"
     },

--- a/legislative/Q53542918/Q53546087/popolo-m17n.json
+++ b/legislative/Q53542918/Q53546087/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "I Local Electoral District of San Luis Potosi",
-        "es": "I Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "I Local Electoral District of San Luis Potosi",
+        "lang:es": "I Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "II Local Electoral District of San Luis Potosi",
-        "es": "II Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "II Local Electoral District of San Luis Potosi",
+        "lang:es": "II Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "III Local Electoral District of San Luis Potosi",
-        "es": "III Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "III Local Electoral District of San Luis Potosi",
+        "lang:es": "III Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "IV Local Electoral District of San Luis Potosi",
-        "es": "IV Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "IV Local Electoral District of San Luis Potosi",
+        "lang:es": "IV Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "V Local Electoral District of San Luis Potosi",
-        "es": "V Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "V Local Electoral District of San Luis Potosi",
+        "lang:es": "V Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "VI Local Electoral District of San Luis Potosi",
-        "es": "VI Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "VI Local Electoral District of San Luis Potosi",
+        "lang:es": "VI Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "VII Local Electoral District of San Luis Potosi",
-        "es": "VII Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "VII Local Electoral District of San Luis Potosi",
+        "lang:es": "VII Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "VIII Local Electoral District of San Luis Potosi",
-        "es": "VIII Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "VIII Local Electoral District of San Luis Potosi",
+        "lang:es": "VIII Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "IX Local Electoral District of San Luis Potosi",
-        "es": "IX Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "IX Local Electoral District of San Luis Potosi",
+        "lang:es": "IX Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "X Local Electoral District of San Luis Potosi",
-        "es": "X Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "X Local Electoral District of San Luis Potosi",
+        "lang:es": "X Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "XI Local Electoral District of San Luis Potosi",
-        "es": "XI Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "XI Local Electoral District of San Luis Potosi",
+        "lang:es": "XI Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "XII Local Electoral District of San Luis Potosi",
-        "es": "XII Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "XII Local Electoral District of San Luis Potosi",
+        "lang:es": "XII Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "XIII Local Electoral District of San Luis Potosi",
-        "es": "XIII Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "XIII Local Electoral District of San Luis Potosi",
+        "lang:es": "XIII Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "XIV Local Electoral District of San Luis Potosi",
-        "es": "XIV Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "XIV Local Electoral District of San Luis Potosi",
+        "lang:es": "XIV Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of San Luis Potosi"
       },
       "name": {
-        "en": "XV Local Electoral District of San Luis Potosi",
-        "es": "XV Distrito Electoral Local de San Luis Potosi"
+        "lang:en": "XV Local Electoral District of San Luis Potosi",
+        "lang:es": "XV Distrito Electoral Local de San Luis Potosi"
       },
       "parent_id": "Q78980"
     },

--- a/legislative/Q53542920/Q53546106/popolo-m17n.json
+++ b/legislative/Q53542920/Q53546106/popolo-m17n.json
@@ -74,8 +74,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "I Local Electoral District of Tlaxcala",
-        "es": "I Distrito Electoral Local de Tlaxcala"
+        "lang:en": "I Local Electoral District of Tlaxcala",
+        "lang:es": "I Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -98,8 +98,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "II Local Electoral District of Tlaxcala",
-        "es": "II Distrito Electoral Local de Tlaxcala"
+        "lang:en": "II Local Electoral District of Tlaxcala",
+        "lang:es": "II Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -122,8 +122,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "III Local Electoral District of Tlaxcala",
-        "es": "III Distrito Electoral Local de Tlaxcala"
+        "lang:en": "III Local Electoral District of Tlaxcala",
+        "lang:es": "III Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -146,8 +146,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "IV Local Electoral District of Tlaxcala",
-        "es": "IV Distrito Electoral Local de Tlaxcala"
+        "lang:en": "IV Local Electoral District of Tlaxcala",
+        "lang:es": "IV Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -170,8 +170,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "V Local Electoral District of Tlaxcala",
-        "es": "V Distrito Electoral Local de Tlaxcala"
+        "lang:en": "V Local Electoral District of Tlaxcala",
+        "lang:es": "V Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -194,8 +194,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "VI Local Electoral District of Tlaxcala",
-        "es": "VI Distrito Electoral Local de Tlaxcala"
+        "lang:en": "VI Local Electoral District of Tlaxcala",
+        "lang:es": "VI Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -218,8 +218,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "VII Local Electoral District of Tlaxcala",
-        "es": "VII Distrito Electoral Local de Tlaxcala"
+        "lang:en": "VII Local Electoral District of Tlaxcala",
+        "lang:es": "VII Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -242,8 +242,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "VIII Local Electoral District of Tlaxcala",
-        "es": "VIII Distrito Electoral Local de Tlaxcala"
+        "lang:en": "VIII Local Electoral District of Tlaxcala",
+        "lang:es": "VIII Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -266,8 +266,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "IX Local Electoral District of Tlaxcala",
-        "es": "IX Distrito Electoral Local de Tlaxcala"
+        "lang:en": "IX Local Electoral District of Tlaxcala",
+        "lang:es": "IX Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -290,8 +290,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "X Local Electoral District of Tlaxcala",
-        "es": "X Distrito Electoral Local de Tlaxcala"
+        "lang:en": "X Local Electoral District of Tlaxcala",
+        "lang:es": "X Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -314,8 +314,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "XI Local Electoral District of Tlaxcala",
-        "es": "XI Distrito Electoral Local de Tlaxcala"
+        "lang:en": "XI Local Electoral District of Tlaxcala",
+        "lang:es": "XI Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -338,8 +338,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "XII Local Electoral District of Tlaxcala",
-        "es": "XII Distrito Electoral Local de Tlaxcala"
+        "lang:en": "XII Local Electoral District of Tlaxcala",
+        "lang:es": "XII Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -362,8 +362,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "XIII Local Electoral District of Tlaxcala",
-        "es": "XIII Distrito Electoral Local de Tlaxcala"
+        "lang:en": "XIII Local Electoral District of Tlaxcala",
+        "lang:es": "XIII Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -386,8 +386,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "XIV Local Electoral District of Tlaxcala",
-        "es": "XIV Distrito Electoral Local de Tlaxcala"
+        "lang:en": "XIV Local Electoral District of Tlaxcala",
+        "lang:es": "XIV Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },
@@ -410,8 +410,8 @@
         "lang:en": "local electoral district of Tlaxcala"
       },
       "name": {
-        "en": "XV Local Electoral District of Tlaxcala",
-        "es": "XV Distrito Electoral Local de Tlaxcala"
+        "lang:en": "XV Local Electoral District of Tlaxcala",
+        "lang:es": "XV Distrito Electoral Local de Tlaxcala"
       },
       "parent_id": "Q82681"
     },

--- a/legislative/Q53547430/Q53559890/popolo-m17n.json
+++ b/legislative/Q53547430/Q53559890/popolo-m17n.json
@@ -76,7 +76,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Ecatepec de Morelos"
+        "lang:es": "Ecatepec de Morelos"
       },
       "parent_id": "Q82112"
     },

--- a/legislative/Q53547431/Q53559891/popolo-m17n.json
+++ b/legislative/Q53547431/Q53559891/popolo-m17n.json
@@ -106,7 +106,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Tijuana"
+        "lang:es": "Tijuana"
       },
       "parent_id": "Q58731"
     },

--- a/legislative/Q53547432/Q53559892/popolo-m17n.json
+++ b/legislative/Q53547432/Q53559892/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Puebla"
+        "lang:es": "Puebla"
       },
       "parent_id": "Q79923"
     },

--- a/legislative/Q53547435/Q53559893/popolo-m17n.json
+++ b/legislative/Q53547435/Q53559893/popolo-m17n.json
@@ -76,7 +76,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Guadalajara"
+        "lang:es": "Guadalajara"
       },
       "parent_id": "Q13160"
     },

--- a/legislative/Q53547437/Q53559894/popolo-m17n.json
+++ b/legislative/Q53547437/Q53559894/popolo-m17n.json
@@ -97,7 +97,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "León"
+        "lang:es": "León"
       },
       "parent_id": "Q46475"
     },

--- a/legislative/Q53547439/Q53559895/popolo-m17n.json
+++ b/legislative/Q53547439/Q53559895/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Juárez"
+        "lang:es": "Juárez"
       },
       "parent_id": "Q655"
     },

--- a/legislative/Q53547442/Q53559896/popolo-m17n.json
+++ b/legislative/Q53547442/Q53559896/popolo-m17n.json
@@ -51,7 +51,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Zapopan"
+        "lang:es": "Zapopan"
       },
       "parent_id": "Q13160"
     },

--- a/legislative/Q53547443/Q53559898/popolo-m17n.json
+++ b/legislative/Q53547443/Q53559898/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "municipality of Mexico"
       },
       "name": {
-        "es": "Nezahualcóyotl"
+        "lang:es": "Nezahualcóyotl"
       },
       "parent_id": "Q82112"
     },

--- a/legislative/Q53547444/Q53559899/popolo-m17n.json
+++ b/legislative/Q53547444/Q53559899/popolo-m17n.json
@@ -51,7 +51,7 @@
         "lang:en": "municipality of Nuevo León"
       },
       "name": {
-        "es": "Monterrey"
+        "lang:es": "Monterrey"
       },
       "parent_id": "Q15282"
     },

--- a/legislative/Q5783176/Q53546038/popolo-m17n.json
+++ b/legislative/Q5783176/Q53546038/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "I Local Electoral District of Chihuahua",
-        "es": "I Distrito Electoral Local de Chihuahua"
+        "lang:en": "I Local Electoral District of Chihuahua",
+        "lang:es": "I Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "II Local Electoral District of Chihuahua",
-        "es": "II Distrito Electoral Local de Chihuahua"
+        "lang:en": "II Local Electoral District of Chihuahua",
+        "lang:es": "II Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "III Local Electoral District of Chihuahua",
-        "es": "III Distrito Electoral Local de Chihuahua"
+        "lang:en": "III Local Electoral District of Chihuahua",
+        "lang:es": "III Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "IV Local Electoral District of Chihuahua",
-        "es": "IV Distrito Electoral Local de Chihuahua"
+        "lang:en": "IV Local Electoral District of Chihuahua",
+        "lang:es": "IV Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "V Local Electoral District of Chihuahua",
-        "es": "V Distrito Electoral Local de Chihuahua"
+        "lang:en": "V Local Electoral District of Chihuahua",
+        "lang:es": "V Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "VI Local Electoral District of Chihuahua",
-        "es": "VI Distrito Electoral Local de Chihuahua"
+        "lang:en": "VI Local Electoral District of Chihuahua",
+        "lang:es": "VI Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "VII Local Electoral District of Chihuahua",
-        "es": "VII Distrito Electoral Local de Chihuahua"
+        "lang:en": "VII Local Electoral District of Chihuahua",
+        "lang:es": "VII Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "VIII Local Electoral District of Chihuahua",
-        "es": "VIII Distrito Electoral Local de Chihuahua"
+        "lang:en": "VIII Local Electoral District of Chihuahua",
+        "lang:es": "VIII Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "IX Local Electoral District of Chihuahua",
-        "es": "IX Distrito Electoral Local de Chihuahua"
+        "lang:en": "IX Local Electoral District of Chihuahua",
+        "lang:es": "IX Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "X Local Electoral District of Chihuahua",
-        "es": "X Distrito Electoral Local de Chihuahua"
+        "lang:en": "X Local Electoral District of Chihuahua",
+        "lang:es": "X Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XI Local Electoral District of Chihuahua",
-        "es": "XI Distrito Electoral Local de Chihuahua"
+        "lang:en": "XI Local Electoral District of Chihuahua",
+        "lang:es": "XI Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XII Local Electoral District of Chihuahua",
-        "es": "XII Distrito Electoral Local de Chihuahua"
+        "lang:en": "XII Local Electoral District of Chihuahua",
+        "lang:es": "XII Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XIII Local Electoral District of Chihuahua",
-        "es": "XIII Distrito Electoral Local de Chihuahua"
+        "lang:en": "XIII Local Electoral District of Chihuahua",
+        "lang:es": "XIII Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XIV Local Electoral District of Chihuahua",
-        "es": "XIV Distrito Electoral Local de Chihuahua"
+        "lang:en": "XIV Local Electoral District of Chihuahua",
+        "lang:es": "XIV Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XV Local Electoral District of Chihuahua",
-        "es": "XV Distrito Electoral Local de Chihuahua"
+        "lang:en": "XV Local Electoral District of Chihuahua",
+        "lang:es": "XV Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XVI Local Electoral District of Chihuahua",
-        "es": "XVI Distrito Electoral Local de Chihuahua"
+        "lang:en": "XVI Local Electoral District of Chihuahua",
+        "lang:es": "XVI Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XVII Local Electoral District of Chihuahua",
-        "es": "XVII Distrito Electoral Local de Chihuahua"
+        "lang:en": "XVII Local Electoral District of Chihuahua",
+        "lang:es": "XVII Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Chihuahua",
-        "es": "XVIII Distrito Electoral Local de Chihuahua"
+        "lang:en": "XVIII Local Electoral District of Chihuahua",
+        "lang:es": "XVIII Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XIX Local Electoral District of Chihuahua",
-        "es": "XIX Distrito Electoral Local de Chihuahua"
+        "lang:en": "XIX Local Electoral District of Chihuahua",
+        "lang:es": "XIX Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XX Local Electoral District of Chihuahua",
-        "es": "XX Distrito Electoral Local de Chihuahua"
+        "lang:en": "XX Local Electoral District of Chihuahua",
+        "lang:es": "XX Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XXI Local Electoral District of Chihuahua",
-        "es": "XXI Distrito Electoral Local de Chihuahua"
+        "lang:en": "XXI Local Electoral District of Chihuahua",
+        "lang:es": "XXI Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Chihuahua"
       },
       "name": {
-        "en": "XXII Local Electoral District of Chihuahua",
-        "es": "XXII Distrito Electoral Local de Chihuahua"
+        "lang:en": "XXII Local Electoral District of Chihuahua",
+        "lang:es": "XXII Distrito Electoral Local de Chihuahua"
       },
       "parent_id": "Q655"
     },

--- a/legislative/Q5783178/Q53546064/popolo-m17n.json
+++ b/legislative/Q5783178/Q53546064/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "I Local Electoral District of Morelos",
-        "es": "I Distrito Electoral Local de Morelos"
+        "lang:en": "I Local Electoral District of Morelos",
+        "lang:es": "I Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "II Local Electoral District of Morelos",
-        "es": "II Distrito Electoral Local de Morelos"
+        "lang:en": "II Local Electoral District of Morelos",
+        "lang:es": "II Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "III Local Electoral District of Morelos",
-        "es": "III Distrito Electoral Local de Morelos"
+        "lang:en": "III Local Electoral District of Morelos",
+        "lang:es": "III Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "IV Local Electoral District of Morelos",
-        "es": "IV Distrito Electoral Local de Morelos"
+        "lang:en": "IV Local Electoral District of Morelos",
+        "lang:es": "IV Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "V Local Electoral District of Morelos",
-        "es": "V Distrito Electoral Local de Morelos"
+        "lang:en": "V Local Electoral District of Morelos",
+        "lang:es": "V Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "VI Local Electoral District of Morelos",
-        "es": "VI Distrito Electoral Local de Morelos"
+        "lang:en": "VI Local Electoral District of Morelos",
+        "lang:es": "VI Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "VII Local Electoral District of Morelos",
-        "es": "VII Distrito Electoral Local de Morelos"
+        "lang:en": "VII Local Electoral District of Morelos",
+        "lang:es": "VII Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "VIII Local Electoral District of Morelos",
-        "es": "VIII Distrito Electoral Local de Morelos"
+        "lang:en": "VIII Local Electoral District of Morelos",
+        "lang:es": "VIII Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "IX Local Electoral District of Morelos",
-        "es": "IX Distrito Electoral Local de Morelos"
+        "lang:en": "IX Local Electoral District of Morelos",
+        "lang:es": "IX Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "X Local Electoral District of Morelos",
-        "es": "X Distrito Electoral Local de Morelos"
+        "lang:en": "X Local Electoral District of Morelos",
+        "lang:es": "X Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "XI Local Electoral District of Morelos",
-        "es": "XI Distrito Electoral Local de Morelos"
+        "lang:en": "XI Local Electoral District of Morelos",
+        "lang:es": "XI Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Morelos"
       },
       "name": {
-        "en": "XII Local Electoral District of Morelos",
-        "es": "XII Distrito Electoral Local de Morelos"
+        "lang:en": "XII Local Electoral District of Morelos",
+        "lang:es": "XII Distrito Electoral Local de Morelos"
       },
       "parent_id": "Q66117"
     },

--- a/legislative/Q5783180/Q53546089/popolo-m17n.json
+++ b/legislative/Q5783180/Q53546089/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "I Local Electoral District of Sinaloa",
-        "es": "I Distrito Electoral Local de Sinaloa"
+        "lang:en": "I Local Electoral District of Sinaloa",
+        "lang:es": "I Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "II Local Electoral District of Sinaloa",
-        "es": "II Distrito Electoral Local de Sinaloa"
+        "lang:en": "II Local Electoral District of Sinaloa",
+        "lang:es": "II Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "III Local Electoral District of Sinaloa",
-        "es": "III Distrito Electoral Local de Sinaloa"
+        "lang:en": "III Local Electoral District of Sinaloa",
+        "lang:es": "III Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "IV Local Electoral District of Sinaloa",
-        "es": "IV Distrito Electoral Local de Sinaloa"
+        "lang:en": "IV Local Electoral District of Sinaloa",
+        "lang:es": "IV Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "V Local Electoral District of Sinaloa",
-        "es": "V Distrito Electoral Local de Sinaloa"
+        "lang:en": "V Local Electoral District of Sinaloa",
+        "lang:es": "V Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "VI Local Electoral District of Sinaloa",
-        "es": "VI Distrito Electoral Local de Sinaloa"
+        "lang:en": "VI Local Electoral District of Sinaloa",
+        "lang:es": "VI Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "VII Local Electoral District of Sinaloa",
-        "es": "VII Distrito Electoral Local de Sinaloa"
+        "lang:en": "VII Local Electoral District of Sinaloa",
+        "lang:es": "VII Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "VIII Local Electoral District of Sinaloa",
-        "es": "VIII Distrito Electoral Local de Sinaloa"
+        "lang:en": "VIII Local Electoral District of Sinaloa",
+        "lang:es": "VIII Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "IX Local Electoral District of Sinaloa",
-        "es": "IX Distrito Electoral Local de Sinaloa"
+        "lang:en": "IX Local Electoral District of Sinaloa",
+        "lang:es": "IX Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "X Local Electoral District of Sinaloa",
-        "es": "X Distrito Electoral Local de Sinaloa"
+        "lang:en": "X Local Electoral District of Sinaloa",
+        "lang:es": "X Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XI Local Electoral District of Sinaloa",
-        "es": "XI Distrito Electoral Local de Sinaloa"
+        "lang:en": "XI Local Electoral District of Sinaloa",
+        "lang:es": "XI Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XII Local Electoral District of Sinaloa",
-        "es": "XII Distrito Electoral Local de Sinaloa"
+        "lang:en": "XII Local Electoral District of Sinaloa",
+        "lang:es": "XII Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XIII Local Electoral District of Sinaloa",
-        "es": "XIII Distrito Electoral Local de Sinaloa"
+        "lang:en": "XIII Local Electoral District of Sinaloa",
+        "lang:es": "XIII Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XIV Local Electoral District of Sinaloa",
-        "es": "XIV Distrito Electoral Local de Sinaloa"
+        "lang:en": "XIV Local Electoral District of Sinaloa",
+        "lang:es": "XIV Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XV Local Electoral District of Sinaloa",
-        "es": "XV Distrito Electoral Local de Sinaloa"
+        "lang:en": "XV Local Electoral District of Sinaloa",
+        "lang:es": "XV Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XVI Local Electoral District of Sinaloa",
-        "es": "XVI Distrito Electoral Local de Sinaloa"
+        "lang:en": "XVI Local Electoral District of Sinaloa",
+        "lang:es": "XVI Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XVII Local Electoral District of Sinaloa",
-        "es": "XVII Distrito Electoral Local de Sinaloa"
+        "lang:en": "XVII Local Electoral District of Sinaloa",
+        "lang:es": "XVII Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Sinaloa",
-        "es": "XVIII Distrito Electoral Local de Sinaloa"
+        "lang:en": "XVIII Local Electoral District of Sinaloa",
+        "lang:es": "XVIII Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XIX Local Electoral District of Sinaloa",
-        "es": "XIX Distrito Electoral Local de Sinaloa"
+        "lang:en": "XIX Local Electoral District of Sinaloa",
+        "lang:es": "XIX Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XX Local Electoral District of Sinaloa",
-        "es": "XX Distrito Electoral Local de Sinaloa"
+        "lang:en": "XX Local Electoral District of Sinaloa",
+        "lang:es": "XX Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XXI Local Electoral District of Sinaloa",
-        "es": "XXI Distrito Electoral Local de Sinaloa"
+        "lang:en": "XXI Local Electoral District of Sinaloa",
+        "lang:es": "XXI Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XXII Local Electoral District of Sinaloa",
-        "es": "XXII Distrito Electoral Local de Sinaloa"
+        "lang:en": "XXII Local Electoral District of Sinaloa",
+        "lang:es": "XXII Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -553,8 +553,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XXIII Local Electoral District of Sinaloa",
-        "es": "XXIII Distrito Electoral Local de Sinaloa"
+        "lang:en": "XXIII Local Electoral District of Sinaloa",
+        "lang:es": "XXIII Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },
@@ -577,8 +577,8 @@
         "lang:en": "local electoral district of Sinaloa"
       },
       "name": {
-        "en": "XXIV Local Electoral District of Sinaloa",
-        "es": "XXIV Distrito Electoral Local de Sinaloa"
+        "lang:en": "XXIV Local Electoral District of Sinaloa",
+        "lang:es": "XXIV Distrito Electoral Local de Sinaloa"
       },
       "parent_id": "Q80252"
     },

--- a/legislative/Q610045/Q53546058/popolo-m17n.json
+++ b/legislative/Q610045/Q53546058/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "I Local Electoral District of Guerrero",
-        "es": "I Distrito Electoral Local de Guerrero"
+        "lang:en": "I Local Electoral District of Guerrero",
+        "lang:es": "I Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -49,8 +49,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "II Local Electoral District of Guerrero",
-        "es": "II Distrito Electoral Local de Guerrero"
+        "lang:en": "II Local Electoral District of Guerrero",
+        "lang:es": "II Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -73,8 +73,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "III Local Electoral District of Guerrero",
-        "es": "III Distrito Electoral Local de Guerrero"
+        "lang:en": "III Local Electoral District of Guerrero",
+        "lang:es": "III Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -97,8 +97,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "IV Local Electoral District of Guerrero",
-        "es": "IV Distrito Electoral Local de Guerrero"
+        "lang:en": "IV Local Electoral District of Guerrero",
+        "lang:es": "IV Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -121,8 +121,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "V Local Electoral District of Guerrero",
-        "es": "V Distrito Electoral Local de Guerrero"
+        "lang:en": "V Local Electoral District of Guerrero",
+        "lang:es": "V Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -145,8 +145,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "VI Local Electoral District of Guerrero",
-        "es": "VI Distrito Electoral Local de Guerrero"
+        "lang:en": "VI Local Electoral District of Guerrero",
+        "lang:es": "VI Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -169,8 +169,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "VII Local Electoral District of Guerrero",
-        "es": "VII Distrito Electoral Local de Guerrero"
+        "lang:en": "VII Local Electoral District of Guerrero",
+        "lang:es": "VII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -193,8 +193,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "VIII Local Electoral District of Guerrero",
-        "es": "VIII Distrito Electoral Local de Guerrero"
+        "lang:en": "VIII Local Electoral District of Guerrero",
+        "lang:es": "VIII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -217,8 +217,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "IX Local Electoral District of Guerrero",
-        "es": "IX Distrito Electoral Local de Guerrero"
+        "lang:en": "IX Local Electoral District of Guerrero",
+        "lang:es": "IX Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -241,8 +241,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "X Local Electoral District of Guerrero",
-        "es": "X Distrito Electoral Local de Guerrero"
+        "lang:en": "X Local Electoral District of Guerrero",
+        "lang:es": "X Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -265,8 +265,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XI Local Electoral District of Guerrero",
-        "es": "XI Distrito Electoral Local de Guerrero"
+        "lang:en": "XI Local Electoral District of Guerrero",
+        "lang:es": "XI Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -289,8 +289,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XII Local Electoral District of Guerrero",
-        "es": "XII Distrito Electoral Local de Guerrero"
+        "lang:en": "XII Local Electoral District of Guerrero",
+        "lang:es": "XII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -313,8 +313,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XIII Local Electoral District of Guerrero",
-        "es": "XIII Distrito Electoral Local de Guerrero"
+        "lang:en": "XIII Local Electoral District of Guerrero",
+        "lang:es": "XIII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -337,8 +337,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XIV Local Electoral District of Guerrero",
-        "es": "XIV Distrito Electoral Local de Guerrero"
+        "lang:en": "XIV Local Electoral District of Guerrero",
+        "lang:es": "XIV Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -361,8 +361,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XV Local Electoral District of Guerrero",
-        "es": "XV Distrito Electoral Local de Guerrero"
+        "lang:en": "XV Local Electoral District of Guerrero",
+        "lang:es": "XV Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -385,8 +385,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XVI Local Electoral District of Guerrero",
-        "es": "XVI Distrito Electoral Local de Guerrero"
+        "lang:en": "XVI Local Electoral District of Guerrero",
+        "lang:es": "XVI Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -409,8 +409,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XVII Local Electoral District of Guerrero",
-        "es": "XVII Distrito Electoral Local de Guerrero"
+        "lang:en": "XVII Local Electoral District of Guerrero",
+        "lang:es": "XVII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -433,8 +433,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XVIII Local Electoral District of Guerrero",
-        "es": "XVIII Distrito Electoral Local de Guerrero"
+        "lang:en": "XVIII Local Electoral District of Guerrero",
+        "lang:es": "XVIII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -457,8 +457,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XIX Local Electoral District of Guerrero",
-        "es": "XIX Distrito Electoral Local de Guerrero"
+        "lang:en": "XIX Local Electoral District of Guerrero",
+        "lang:es": "XIX Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -481,8 +481,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XX Local Electoral District of Guerrero",
-        "es": "XX Distrito Electoral Local de Guerrero"
+        "lang:en": "XX Local Electoral District of Guerrero",
+        "lang:es": "XX Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -505,8 +505,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XXI Local Electoral District of Guerrero",
-        "es": "XXI Distrito Electoral Local de Guerrero"
+        "lang:en": "XXI Local Electoral District of Guerrero",
+        "lang:es": "XXI Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -529,8 +529,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XXII Local Electoral District of Guerrero",
-        "es": "XXII Distrito Electoral Local de Guerrero"
+        "lang:en": "XXII Local Electoral District of Guerrero",
+        "lang:es": "XXII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -553,8 +553,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XXIII Local Electoral District of Guerrero",
-        "es": "XXIII Distrito Electoral Local de Guerrero"
+        "lang:en": "XXIII Local Electoral District of Guerrero",
+        "lang:es": "XXIII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -577,8 +577,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XXIV Local Electoral District of Guerrero",
-        "es": "XXIV Distrito Electoral Local de Guerrero"
+        "lang:en": "XXIV Local Electoral District of Guerrero",
+        "lang:es": "XXIV Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -601,8 +601,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XXV Local Electoral District of Guerrero",
-        "es": "XXV Distrito Electoral Local de Guerrero"
+        "lang:en": "XXV Local Electoral District of Guerrero",
+        "lang:es": "XXV Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -625,8 +625,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XXVI Local Electoral District of Guerrero",
-        "es": "XXVI Distrito Electoral Local de Guerrero"
+        "lang:en": "XXVI Local Electoral District of Guerrero",
+        "lang:es": "XXVI Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -649,8 +649,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XXVII Local Electoral District of Guerrero",
-        "es": "XXVII Distrito Electoral Local de Guerrero"
+        "lang:en": "XXVII Local Electoral District of Guerrero",
+        "lang:es": "XXVII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },
@@ -673,8 +673,8 @@
         "lang:en": "local electoral district of Guerrero"
       },
       "name": {
-        "en": "XXVIII Local Electoral District of Guerrero",
-        "es": "XXVIII Distrito Electoral Local de Guerrero"
+        "lang:en": "XXVIII Local Electoral District of Guerrero",
+        "lang:es": "XXVIII Distrito Electoral Local de Guerrero"
       },
       "parent_id": "Q60158"
     },


### PR DESCRIPTION
Some of the boundary name field mappings are missing their "lang:" prefix, which this adds.

This otherwise makes a later step in the build process fail, as the language codes are unexpected.